### PR TITLE
Change rules for the uninformative node

### DIFF
--- a/src/nodes/uninformative.jl
+++ b/src/nodes/uninformative.jl
@@ -5,3 +5,27 @@ struct Uninformative end
 @node Uninformative Stochastic [out]
 
 @average_energy Uninformative (q_out::Any,) = entropy(q_out)
+
+function BayesBase.default_prod_rule(::Type{<:Uninformative}, ::Type{T}) where {T}
+    return PreserveTypeProd(T)
+end
+
+function BayesBase.default_prod_rule(::Type{T}, ::Type{<:Uninformative}) where {T}
+    return PreserveTypeProd(T)
+end
+
+function BayesBase.default_prod_rule(::Type{<:Uninformative}, ::Type{<:Uninformative})
+    return PreserveTypeProd(Uninformative)
+end
+
+function Base.prod(::PreserveTypeProd{T}, left::Uninformative, right::T) where {T}
+    return right
+end
+
+function Base.prod(::PreserveTypeProd{T}, left::T, right::Uninformative) where {T}
+    return left
+end
+
+function Base.prod(::PreserveTypeProd{Uninformative}, left::Uninformative, right::Uninformative)
+    return Uninformative()
+end

--- a/src/rules/uninformative/out.jl
+++ b/src/rules/uninformative/out.jl
@@ -1,3 +1,2 @@
-export rule
 
-@rule Uninformative(:out, Marginalisation) () = missing
+@rule Uninformative(:out, Marginalisation) () = Uninformative()

--- a/test/nodes/test_uninformative.jl
+++ b/test/nodes/test_uninformative.jl
@@ -1,0 +1,24 @@
+module UninformativeNodeTest
+
+using Test, ReactiveMP, Random, BayesBase, ExponentialFamily
+
+@testset "UninformativeNode" begin
+
+    @testset "Creation" begin
+        node = make_node(Uninformative)
+
+        @test functionalform(node) === Uninformative
+        @test sdtype(node) === Stochastic()
+        @test name.(interfaces(node)) === (:out, )
+        @test factorisation(node) === ((1, ),)
+        @test localmarginalnames(node) === (:out,)
+        @test metadata(node) === nothing
+    end
+
+    @testset "Product must not be affected" begin 
+        @test prod(GenericProd(), Uninformative(), NormalMeanVariance(0, 1)) == NormalMeanVariance(0, 1)
+        @test prod(GenericProd(), NormalMeanVariance(3, 4), Uninformative()) == NormalMeanVariance(3, 4)
+        @test prod(GenericProd(), Uninformative(), Uninformative()) === Uninformative()
+    end
+end
+end

--- a/test/nodes/test_uninformative.jl
+++ b/test/nodes/test_uninformative.jl
@@ -3,19 +3,18 @@ module UninformativeNodeTest
 using Test, ReactiveMP, Random, BayesBase, ExponentialFamily
 
 @testset "UninformativeNode" begin
-
     @testset "Creation" begin
         node = make_node(Uninformative)
 
         @test functionalform(node) === Uninformative
         @test sdtype(node) === Stochastic()
-        @test name.(interfaces(node)) === (:out, )
-        @test factorisation(node) === ((1, ),)
+        @test name.(interfaces(node)) === (:out,)
+        @test factorisation(node) === ((1,),)
         @test localmarginalnames(node) === (:out,)
         @test metadata(node) === nothing
     end
 
-    @testset "Product must not be affected" begin 
+    @testset "Product must not be affected" begin
         @test prod(GenericProd(), Uninformative(), NormalMeanVariance(0, 1)) == NormalMeanVariance(0, 1)
         @test prod(GenericProd(), NormalMeanVariance(3, 4), Uninformative()) == NormalMeanVariance(3, 4)
         @test prod(GenericProd(), Uninformative(), Uninformative()) === Uninformative()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,6 +254,7 @@ end
     addtests(testrunner, "nodes/test_normal_mixture.jl")
     addtests(testrunner, "nodes/test_softdot.jl")
     addtests(testrunner, "nodes/test_continuous_transition.jl")
+    addtests(testrunner, "nodes/test_uninformative.jl")
 
     addtests(testrunner, "rules/uniform/test_out.jl")
 


### PR DESCRIPTION
Another attempt to #373 . Spotted by @wouterwln & @bartvanerp . New logic for the predictions did not take into account that someone would want to define a rule that accepts `Missing` as an argument, which is sent out of `Uninformative` node.  This PR changes the outbound message rule for the `Uninformative` node and allows users to define their rules with `Uninformative` arguments.