### PR TITLE
add sdtype method for distribution objects

### DIFF
--- a/src/nodes/nodes.jl
+++ b/src/nodes/nodes.jl
@@ -103,13 +103,14 @@ Returns either `Deterministic` or `Stochastic` for a given object (if defined).
 
 See also: [`Deterministic`](@ref), [`Stochastic`](@ref), [`isdeterministic`](@ref), [`isstochastic`](@ref)
 """
-function sdtype end
+sdtype(any) = error("Unknown if an object of type `$(typeof(any))` is stochastic or deterministic.")
 
 # Any `Type` is considered to be a deterministic mapping unless stated otherwise (By convention, any `Distribution` type is not deterministic)
 # E.g. `Matrix` is not an instance of the `Function` abstract type, however we would like to pretend it is a deterministic function
 sdtype(::Type{T}) where {T}    = Deterministic()
-sdtype(::Type{<:Distribution}) = Stochastic()
 sdtype(::Function)             = Deterministic()
+sdtype(::Type{<:Distribution}) = Stochastic()
+sdtype(::Distribution)         = Stochastic()
 
 """
     as_node_symbol(type)

--- a/test/nodes/nodes_tests.jl
+++ b/test/nodes/nodes_tests.jl
@@ -29,7 +29,7 @@
 end
 
 @testitem "sdtype" begin
-    
+    using Distributions
 
     @test isdeterministic(Deterministic()) === true
     @test isdeterministic(Deterministic) === true
@@ -41,7 +41,11 @@ end
     @test isstochastic(Stochastic) === true
 
     @test sdtype(() -> nothing) === Deterministic()
-    @test_throws MethodError sdtype(0)
+    @test sdtype(Normal(0.0, 1.0)) === Stochastic()
+
+    @test_throws "Unknown if an object of type `Vector{Float64}` is stochastic or deterministic." sdtype([ 1.0, 2.0, 3.0 ])
+    @test_throws "Unknown if an object of type `Matrix{Float64}` is stochastic or deterministic." sdtype([ 1.0 0.0; 0.0 1.0 ])
+    @test_throws "Unknown if an object of type `Int64` is stochastic or deterministic." sdtype(0)
 end
 
 @testitem "is_predefined_node" begin 


### PR DESCRIPTION
Fixes a bug found by @albertpod . (The formatter fails, but its an issue with the entire version. Lets skip it for now, locally tests pass.)