### PR TITLE
Fix for linked datavars

### DIFF
--- a/src/message.jl
+++ b/src/message.jl
@@ -241,12 +241,13 @@ dropproxytype(::Type{<:Message{T}}) where {T} = T
 
 ## Message observable 
 
-struct MessageObservable{M <: AbstractMessage} <: Subscribable{M}
-    subject :: Rocket.RecentSubjectInstance{M, Subject{M, AsapScheduler, AsapScheduler}}
+struct MessageObservable{M <: AbstractMessage, S <: AbstractSubject} <: Subscribable{M}
+    subject :: S
     stream  :: LazyObservable{M}
 end
 
-MessageObservable(::Type{M} = AbstractMessage) where {M} = MessageObservable{M}(RecentSubject(M), lazy(M))
+MessageObservable(::Type{M} = AbstractMessage) where {M} = MessageObservable(RecentSubject(M), lazy(M))
+MessageObservable(subject::AbstractSubject{M}) where {M} = MessageObservable(subject, lazy(M))
 
 Rocket.getrecent(observable::MessageObservable) = Rocket.getrecent(observable.subject)
 

--- a/src/message.jl
+++ b/src/message.jl
@@ -241,13 +241,12 @@ dropproxytype(::Type{<:Message{T}}) where {T} = T
 
 ## Message observable 
 
-struct MessageObservable{M <: AbstractMessage, S <: AbstractSubject} <: Subscribable{M}
-    subject :: S
+struct MessageObservable{M <: AbstractMessage} <: Subscribable{M}
+    subject :: Rocket.RecentSubjectInstance{M, Subject{M, AsapScheduler, AsapScheduler}}
     stream  :: LazyObservable{M}
 end
 
-MessageObservable(::Type{M} = AbstractMessage) where {M} = MessageObservable(RecentSubject(M), lazy(M))
-MessageObservable(subject::AbstractSubject{M}) where {M} = MessageObservable(subject, lazy(M))
+MessageObservable(::Type{M} = AbstractMessage) where {M} = MessageObservable{M}(RecentSubject(M), lazy(M))
 
 Rocket.getrecent(observable::MessageObservable) = Rocket.getrecent(observable.subject)
 

--- a/src/variables/data.jl
+++ b/src/variables/data.jl
@@ -1,19 +1,17 @@
 export datavar, DataVariable, update!, DataVariableActivationOptions
 
 mutable struct DataVariable{M, P} <: AbstractVariable
-    datastream     :: M
     input_messages :: Vector{MessageObservable{AbstractMessage}}
-    messageout     :: MessageObservable{Message}
     marginal       :: MarginalObservable
+    messageout     :: M
     prediction     :: P
 end
 
 function DataVariable()
-    datastream = Subject(Message)
-    messageout = MessageObservable(Message)
+    messageout = RecentSubject(Message)
     marginal   = MarginalObservable()
     prediction = MarginalObservable()
-    return DataVariable(datastream, Vector{MessageObservable{AbstractMessage}}(), messageout, marginal, prediction)
+    return DataVariable(Vector{MessageObservable{AbstractMessage}}(), marginal, messageout, prediction)
 end
 
 datavar() = DataVariable()
@@ -55,16 +53,15 @@ function activate!(datavar::DataVariable, options::DataVariableActivationOptions
         _setprediction!(datavar, _makeprediction(datavar))
     end
 
-    # If the variable is not linked to another we simply redirect the message from the datastream
-    if !options.linked
-        connect!(datavar.messageout, datavar.datastream)
-    else
+    if options.linked
         # If the variable is linked to another we need to apply a transformation from the linked variables
+        # and redirect the updates to the `datavar` messageout stream
         linkvalues = combineLatestUpdates(map(l -> __link_getmarginal(l), options.args))
-        linkstream = linkvalues |> map(Message, (args) -> let f = options.transform
-            return Message(__apply_link(f, getrecent.(args)), false, false, nothing)
+        linkstream = linkvalues |> map(Any, (args) -> let f = options.transform
+            return __apply_link(f, getrecent.(args))
         end)
-        connect!(datavar.messageout, merged((datavar.datastream, linkstream)))
+        # This subscription should unsubscribe automatically when the linked `datavar`s complete
+        subscribe!(linkstream, (val) -> update!(datavar, val))
     end
 
     # The marginal stream is always the same as the message out
@@ -78,14 +75,15 @@ __link_getmarginal(l::AbstractVariable) = getmarginal(l, IncludeAll())
 __link_getmarginal(l::AbstractArray{<:AbstractVariable}) = getmarginals(l, IncludeAll())
 
 __apply_link(f::F, args) where {F} = __apply_link(f, getdata.(args))
-__apply_link(f::F, args::NTuple{N, PointMass}) where {F, N} = PointMass(f(mean.(args)...))
+__apply_link(f::F, args::NTuple{N, PointMass}) where {F, N} = f(mean.(args)...)
 
 _getmarginal(datavar::DataVariable)       = datavar.marginal
 _setmarginal!(::DataVariable, observable) = error("It is not possible to set a marginal stream for `DataVariable`")
 _makemarginal(::DataVariable)             = error("It is not possible to make marginal stream for `DataVariable`")
 
-update!(datavar::DataVariable, data)      = next!(datavar.datastream, Message(PointMass(data), false, false, nothing))
-update!(datavar::DataVariable, ::Missing) = next!(datavar.datastream, Message(missing, false, false, nothing))
+update!(datavar::DataVariable, data)            = update!(datavar, PointMass(data))
+update!(datavar::DataVariable, data::PointMass) = next!(datavar.messageout, Message(data, false, false, nothing))
+update!(datavar::DataVariable, ::Missing)       = next!(datavar.messageout, Message(missing, false, false, nothing))
 
 function update!(datavars::AbstractArray{<:DataVariable}, data::AbstractArray)
     @assert size(datavars) === size(data) """

--- a/test/nodes/predefined/delta/delta_tests.jl
+++ b/test/nodes/predefined/delta/delta_tests.jl
@@ -16,9 +16,6 @@
 
     activate!(x, RandomVariableActivationOptions())
     activate!(y, DataVariableActivationOptions())
-    # We need to subscribe on the message, otherwise the recent message
-    # will not be propagated to the nodefunction
-    subscribe!(messageout(y, 1), void())
 
     update!(y, 2.0)
 
@@ -50,9 +47,6 @@ end
 
             activate!(r, RandomVariableActivationOptions())
             activate!(d, DataVariableActivationOptions())
-            # We need to subscribe on the message, otherwise the recent message
-            # will not be propagated to the nodefunction
-            subscribe!(messageout(d, 1), void())
 
             return ((:in, r), (:in, d), (:in, c))
         end

--- a/test/nodes/predefined/delta/delta_tests.jl
+++ b/test/nodes/predefined/delta/delta_tests.jl
@@ -40,7 +40,7 @@ end
 
         # In this test we attempt to create a lot of possible combinations 
         # of random, data and const inputs to the delta node
-        function create_interfaces(i) 
+        function create_interfaces(i)
             r = randomvar()
             d = datavar()
             c = constvar(vals[i])

--- a/test/testutilities.jl
+++ b/test/testutilities.jl
@@ -8,12 +8,15 @@ function check_stream_updated_once(f, stream)
     value = Ref{Any}(missing)
     subscription = subscribe!(stream, (new_value) -> begin
         if stream_updated
-            error("Stream was updated more than once")
+            error("Stream was updated more than once. Recorded value: $(value[]). New value: $(new_value)")
         end
         value[] = new_value
         stream_updated = true
     end)
     f()
+    if !stream_updated
+        error("Stream was not updated")
+    end
     @test stream_updated
     unsubscribe!(subscription)
     return value[]

--- a/test/variables/data_tests.jl
+++ b/test/variables/data_tests.jl
@@ -114,7 +114,7 @@ end
             activate!(var, options)
             @test check_stream_not_updated(getmarginal(var))
 
-            marginal = check_stream_updated_once(getmarginal(var)) do 
+            marginal = check_stream_updated_once(getmarginal(var)) do
                 update!(var1, val1)
             end
             @test getdata(marginal) === PointMass(fn(val1, val2))
@@ -131,7 +131,7 @@ end
             activate!(var, options)
             @test check_stream_not_updated(getmarginal(var))
 
-            marginal = check_stream_updated_once(getmarginal(var)) do 
+            marginal = check_stream_updated_once(getmarginal(var)) do
                 update!(var2, val2)
             end
             @test getdata(marginal) === PointMass(fn(val1, val2))
@@ -151,7 +151,7 @@ end
             activate!(var, options)
             @test check_stream_not_updated(getmarginal(var))
 
-            marginal = check_stream_updated_once(getmarginal(var)) do 
+            marginal = check_stream_updated_once(getmarginal(var)) do
                 update!(var1, val1)
                 update!(var2, val2)
             end
@@ -173,11 +173,10 @@ end
             @test check_stream_not_updated(getmarginal(var))
 
             # We still should be able to update the stream manually
-            marginal = check_stream_updated_once(getmarginal(var)) do 
+            marginal = check_stream_updated_once(getmarginal(var)) do
                 update!(var, 4)
             end
             @test getdata(marginal) === PointMass(4)
         end
     end
-
 end

--- a/test/variables/data_tests.jl
+++ b/test/variables/data_tests.jl
@@ -83,11 +83,7 @@ end
             activate!(var, options)
             marginal = check_stream_updated_once(getmarginal(var))
             @test getdata(marginal) === PointMass(fn(val1, val2))
-
-            # `|> take(1)` here is a hack, because the value updates twice
-            # first its being retranslated from the subscription to the marginal, 
-            # then its going to be recomputed again from the linked datavars
-            message = check_stream_updated_once(messageout(var, 1) |> take(1))
+            message = check_stream_updated_once(messageout(var, 1))
             @test getdata(message) === PointMass(fn(val1, val2))
         end
 
@@ -122,12 +118,7 @@ end
                 update!(var1, val1)
             end
             @test getdata(marginal) === PointMass(fn(val1, val2))
-
-            # The message should preserve the value from the previous update
-            # `|> take(1)` here is a hack, because the value updates twice
-            # first its being retranslated from the subscription to the marginal, 
-            # then its going to be recomputed again from the linked datavars
-            message = check_stream_updated_once(messageout(var, 1) |> take(1))
+            message = check_stream_updated_once(messageout(var, 1))
             @test getdata(message) === PointMass(fn(val1, val2))
         end
 
@@ -145,10 +136,7 @@ end
             end
             @test getdata(marginal) === PointMass(fn(val1, val2))
 
-            # `|> take(1)` here is a hack, because the value updates twice
-            # first its being retranslated from the subscription to the marginal, 
-            # then its going to be recomputed again from the linked datavars
-            message = check_stream_updated_once(messageout(var, 1) |> take(1))
+            message = check_stream_updated_once(messageout(var, 1))
             @test getdata(message) === PointMass(fn(val1, val2))
         end
 
@@ -169,10 +157,7 @@ end
             end
             @test getdata(marginal) === PointMass(fn(val1, val2))
 
-            # `|> take(1)` here is a hack, because the value updates twice
-            # first its being retranslated from the subscription to the marginal, 
-            # then its going to be recomputed again from the linked datavars
-            message = check_stream_updated_once(messageout(var, 1) |> take(1))
+            message = check_stream_updated_once(messageout(var, 1))
             @test getdata(message) === PointMass(fn(val1, val2))
         end
 


### PR DESCRIPTION
In our model setup, we handle a special case where certain nodes depend on fixed inputs. Instead of making a new node, we connect them directly to the input. This saves us from writing rules for passing messages and just uses the fixed input values. But, there was a bug. It only worked for marginal calculations, not for messages. This update fixes that, making sure all calculations use the linked inputs, and adds a few tests to make sure it works.

Initially found by @ismailsenoz 