### PR TITLE
Allow functional form constraints that are not sub-typed from AbstractFormConstraint

### DIFF
--- a/src/constraints/form.jl
+++ b/src/constraints/form.jl
@@ -81,9 +81,59 @@ default_form_check_strategy(::UnspecifiedFormConstraint) = FormConstraintCheckLa
 
 default_prod_constraint(::UnspecifiedFormConstraint) = GenericProd()
 
+"""
+    constrain_form(constraint, something)
+
+This function applies a given form constraint to a given object. 
+"""
+function constrain_form end
+
 constrain_form(::UnspecifiedFormConstraint, something) = something
 constrain_form(::UnspecifiedFormConstraint, something::Union{ProductOf, LinearizedProductOf}) =
     error("`ProductOf` object cannot be used as a functional form in inference backend. Use form constraints to restrict the functional form of marginal posteriors.")
+
+"""
+    WrappedFormConstraint(constraint, context)
+
+This is a wrapper for a form constraint object. It allows to pass additional context to the `constrain_form` function.
+By default all objects that are not sub-typed from `AbstractFormConstraint` are wrapped into this object. 
+Use `ReactiveMP.prepare_context` to provide an extra context for a given form constraint, that can be reused between multiple `constrain_form` calls.
+"""
+struct WrappedFormConstraint{C, X} <: AbstractFormConstraint
+    constraint::C
+    context::X
+end
+
+struct WrappedFormConstraintNoContext end
+
+"""
+    prepare_context(constraint)
+
+This function prepares a context for a given form constraint. Returns `WrappedFormConstraintNoContext` if no context is needed (the default behaviour).
+"""
+prepare_context(constraint) = WrappedFormConstraintNoContext()
+
+"""
+    constrain_form(wrapped::WrappedFormConstraint, something)
+
+This function unwraps the `wrapped` object and calls `constrain_form` function with the provided context.
+If the context is not provided, simply calls `constrain_form` with the wrapped constraint. Otherwise passes the context to the `constrain_form` function as the second argument.
+"""
+constrain_form(wrapped::WrappedFormConstraint, something) = constrain_form(wrapped, wrapped.context, something)
+constrain_form(wrapped::WrappedFormConstraint, ::WrappedFormConstraintNoContext, something) = constrain_form(wrapped.constraint, something)
+constrain_form(wrapped::WrappedFormConstraint, context, something) = constrain_form(wrapped.constraint, context, something)
+
+"""
+    preprocess_form_constraints(constraints)
+
+This function preprocesses form constraints and converts the provided objects into a form compatible with ReactiveMP inference backend (if possible). 
+If a tuple of constraints is passed, it creates a `CompositeFormConstraint` object. Wraps unknown form constraints into a `WrappedFormConstraint` object.
+"""
+function preprocess_form_constraints end
+
+preprocess_form_constraints(constraints::Tuple) = CompositeFormConstraint(map(preprocess_form_constraints, constraints))
+preprocess_form_constraints(constraint::AbstractFormConstraint) = constraint
+preprocess_form_constraints(constraint) = WrappedFormConstraint(constraint, prepare_context(constraint))
 
 """
     CompositeFormConstraint

--- a/test/constraints/form_tests.jl
+++ b/test/constraints/form_tests.jl
@@ -1,0 +1,124 @@
+@testitem "`UnspecifiedFormConstraint` should not error on `Distribution` objects" begin
+    using Distributions
+    import ReactiveMP: constrain_form
+
+    @test constrain_form(UnspecifiedFormConstraint(), Beta(1, 1)) == Beta(1, 1)
+    @test constrain_form(UnspecifiedFormConstraint(), Normal(0, 1)) == Normal(0, 1)
+    @test constrain_form(UnspecifiedFormConstraint(), MvNormal([0.0, 0.0])) == MvNormal([0.0, 0.0])
+end
+
+@testitem "`UnspecifiedFormConstraint` should error on `ProductOf` and `LinearizedProductOf` objects" begin
+    using Distributions, BayesBase
+    import ReactiveMP: constrain_form
+
+    @test_throws "object cannot be used as a functional form in inference backend" constrain_form(UnspecifiedFormConstraint(), ProductOf(Beta(1, 1), Normal(0, 1)))
+    @test_throws "object cannot be used as a functional form in inference backend" constrain_form(UnspecifiedFormConstraint(), LinearizedProductOf([Beta(1, 1), Beta(1, 1)], 2))
+end
+
+@testitem "`CompositeFormConstraint` should call the constraints in the specified order" begin
+    import ReactiveMP: constrain_form
+
+    struct FormConstraint1 end
+    struct FormConstraint2 end
+
+    constrain_form(::FormConstraint1, x) = x + 1
+    constrain_form(::FormConstraint2, x) = x * 2
+
+    composite = CompositeFormConstraint((FormConstraint1(), FormConstraint2()))
+    @test constrain_form(composite, 1) == 4
+
+    composite = CompositeFormConstraint((FormConstraint2(), FormConstraint1()))
+    @test constrain_form(composite, 1) == 3
+end
+
+@testitem "`preprocess_form_constraints` should create `CompositeFormConstraint` from a tuple of constraints" begin
+    import ReactiveMP: preprocess_form_constraints, AbstractFormConstraint
+
+    struct FormConstraint1 <: AbstractFormConstraint end
+    struct FormConstraint2 <: AbstractFormConstraint end
+
+    constraints = (FormConstraint1(), FormConstraint2())
+    @test preprocess_form_constraints(constraints) == CompositeFormConstraint(constraints)
+    @test preprocess_form_constraints(FormConstraint1()) == FormConstraint1()
+    @test preprocess_form_constraints(FormConstraint2()) == FormConstraint2()
+end
+
+@testitem "`preprocess_form_constraints` should wrap unknown form constraints into a `WrappedFormConstraint`" begin
+    import ReactiveMP: preprocess_form_constraints, AbstractFormConstraint, WrappedFormConstraint, WrappedFormConstraintNoContext
+
+    struct FormConstraint1 <: AbstractFormConstraint end
+    struct FormConstraint2 end
+    struct FormConstraint3WithContext end
+    struct FormConstraint3Context end
+
+    ReactiveMP.prepare_context(::FormConstraint3WithContext) = FormConstraint3Context()
+
+    @test preprocess_form_constraints(FormConstraint1()) == FormConstraint1()
+    @test preprocess_form_constraints(FormConstraint2()) == WrappedFormConstraint(FormConstraint2(), WrappedFormConstraintNoContext())
+    @test preprocess_form_constraints(FormConstraint3WithContext()) == WrappedFormConstraint(FormConstraint3WithContext(), FormConstraint3Context())
+    @test preprocess_form_constraints((FormConstraint1(), FormConstraint2())) ==
+        CompositeFormConstraint((FormConstraint1(), WrappedFormConstraint(FormConstraint2(), WrappedFormConstraintNoContext())))
+    @test preprocess_form_constraints((FormConstraint1(), FormConstraint3WithContext())) ==
+        CompositeFormConstraint((FormConstraint1(), WrappedFormConstraint(FormConstraint3WithContext(), FormConstraint3Context())))
+    @test preprocess_form_constraints((FormConstraint2(), FormConstraint3WithContext())) == CompositeFormConstraint((
+        WrappedFormConstraint(FormConstraint2(), WrappedFormConstraintNoContext()), WrappedFormConstraint(FormConstraint3WithContext(), FormConstraint3Context())
+    ))
+    @test preprocess_form_constraints((FormConstraint2(), FormConstraint3WithContext(), FormConstraint1())) == CompositeFormConstraint((
+        WrappedFormConstraint(FormConstraint2(), WrappedFormConstraintNoContext()), WrappedFormConstraint(FormConstraint3WithContext(), FormConstraint3Context()), FormConstraint1()
+    ))
+
+    @test preprocess_form_constraints(preprocess_form_constraints(FormConstraint2())) == WrappedFormConstraint(FormConstraint2(), WrappedFormConstraintNoContext())
+    @test preprocess_form_constraints(preprocess_form_constraints(FormConstraint3WithContext())) == WrappedFormConstraint(FormConstraint3WithContext(), FormConstraint3Context())
+end
+
+@testitem "`WrappedFormConstraint` should not pass empty context to the `constrain_form` call" begin 
+    import ReactiveMP: constrain_form, preprocess_form_constraints
+
+    struct FormConstraintWithoutContext end
+
+    function constrain_form(::FormConstraintWithoutContext, x)
+        return x + 1
+    end
+
+    function constrain_form(::FormConstraintWithoutContext, context, x)
+        error("This function should not be called")
+    end
+
+    constraint = preprocess_form_constraints(FormConstraintWithoutContext())
+
+    @test constrain_form(constraint, 1) == 2
+    @test constrain_form(constraint, 2) == 3
+    @test constrain_form(constraint, 7) == 8
+
+end
+
+@testitem "`WrappedFormConstraint` should be able to reuse the context between multiple `constrain_form` calls" begin
+    import ReactiveMP: constrain_form, preprocess_form_constraints
+
+    struct FormConstraintWithContext end
+    mutable struct FormConstraintContext
+        value::Int
+    end
+
+    ReactiveMP.prepare_context(::FormConstraintWithContext) = FormConstraintContext(0)
+
+    function constrain_form(::FormConstraintWithContext, x)
+        error("This function should not be called")
+    end
+
+    function constrain_form(::FormConstraintWithContext, context::FormConstraintContext, x)
+        context.value += 1
+        return x + context.value
+    end
+
+    constraint = preprocess_form_constraints(FormConstraintWithContext())
+
+    @test constrain_form(constraint, 1) == 2
+    @test constraint.context.value === 1
+
+    @test constrain_form(constraint, 2) == 4
+    @test constraint.context.value === 2
+
+    @test constrain_form(constraint, 6) == 9
+    @test constraint.context.value === 3
+end


### PR DESCRIPTION
This PR enables functional form constraints that do not subtype `AbstractFormConstraint`. This is useful for supporting objects defined in different packages, such as `ProjectedTo` from `ExponentialFamilyProjection.jl`.