### PR TITLE
Fix poisson average energy computation

### DIFF
--- a/src/nodes/predefined/poisson.jl
+++ b/src/nodes/predefined/poisson.jl
@@ -27,4 +27,4 @@ end
 
 @average_energy Poisson (q_out::Any, q_l::Any) = mean(q_l) - mean(q_out) * mean(log, q_l) + exp(-mean(q_out)) * __approximate_powersum(Float64, mean(q_out))
 
-@average_energy Poisson (q_out::PointMass, q_l::Any) = mean(q_l) - mean(q_out) * mean(log, q_l) + mapreduce(log, +, (1:mean(q_out)); init=0)
+@average_energy Poisson (q_out::PointMass, q_l::Any) = mean(q_l) - mean(q_out) * mean(log, q_l) + mapreduce(log, +, (1:mean(q_out)); init = 0)

--- a/src/nodes/predefined/poisson.jl
+++ b/src/nodes/predefined/poisson.jl
@@ -27,4 +27,4 @@ end
 
 @average_energy Poisson (q_out::Any, q_l::Any) = mean(q_l) - mean(q_out) * mean(log, q_l) + exp(-mean(q_out)) * __approximate_powersum(Float64, mean(q_out))
 
-@average_energy Poisson (q_out::PointMass, q_l::Any) = mean(q_l) - mean(q_out) * mean(log, q_l) + mapreduce(log, +, (1:mean(q_out)))
+@average_energy Poisson (q_out::PointMass, q_l::Any) = mean(q_l) - mean(q_out) * mean(log, q_l) + mapreduce(log, +, (1:mean(q_out)); init=0)


### PR DESCRIPTION
Average energy computation for Poisson node assumed samples are only positive. However, Poisson samples are non-negative. This PR fixes that by starting the average energy computation from 0.