### PR TITLE
Add conditioners to ProjectedTo to allow for conditioned distributions in marginal computations

### DIFF
--- a/ext/ReactiveMPProjectionExt/ReactiveMPProjectionExt.jl
+++ b/ext/ReactiveMPProjectionExt/ReactiveMPProjectionExt.jl
@@ -7,8 +7,19 @@ struct DivisionOf{A, B}
     denumerator::B
 end
 
+(divisionof::DivisionOf)(x) = logpdf(divisionof, x)
 BayesBase.insupport(d::DivisionOf, p) = insupport(d.numerator, p) && insupport(d.denumerator, p)
 BayesBase.logpdf(d::DivisionOf, p) = logpdf(d.numerator, p) - logpdf(d.denumerator, p)
+
+function BayesBase.prod(::GenericProd, something::DivisionOf, division::DivisionOf) 
+    if division.denumerator == something.numerator
+        return DivisionOf(division.numerator, something.denumerator)
+    elseif division.numerator == something.denumerator
+        return DivisionOf(something.numerator, division.denumerator)
+    else
+        return ProductOf(something, division)
+    end
+end
 
 function BayesBase.prod(::GenericProd, something, division::DivisionOf) 
     return prod(GenericProd(), division, something)
@@ -20,6 +31,10 @@ function BayesBase.prod(::GenericProd, division::DivisionOf, something)
     else
         return ProductOf(division, something)
     end
+end
+
+function BayesBase.prod(::GenericProd, productof::ProductOf, divisionof::DivisionOf) 
+    return ProductOf(productof, divisionof)
 end
 
 include("layout/cvi_projection.jl")

--- a/test/ext/ReactiveMPProjectionExt/rules/marginals_tests.jl
+++ b/test/ext/ReactiveMPProjectionExt/rules/marginals_tests.jl
@@ -33,11 +33,7 @@
 
     @testset "f(x) -> x, x~EF, out~EF with Binomial" begin
         meta = DeltaMeta(method = CVIProjection(), inverse = nothing)
-        inputs_outputs = [
-            (Binomial(3, 0.9), Binomial(7, 0.4)),
-            (Binomial(8, 0.9), Binomial(8, 0.9)),
-            (Binomial(5, 0.01), Binomial(6, 0.98)),
-        ]
+        inputs_outputs = [(Binomial(3, 0.9), Binomial(7, 0.4)), (Binomial(8, 0.9), Binomial(8, 0.9)), (Binomial(5, 0.01), Binomial(6, 0.98))]
         for input_output in inputs_outputs
             m_in = first(input_output)
             m_out = last(input_output)
@@ -54,9 +50,9 @@
     @testset "f(x) -> x, x~EF, out~EF with Categorical" begin
         meta = DeltaMeta(method = CVIProjection(), inverse = nothing)
         inputs_outputs = [
-            (Categorical([1/4, 1/4, 1/2]), Categorical([1/2, 1/8, 3/8])),
-            (Categorical([1/8, 1/8, 3/4]), Categorical([1/16, 13/16, 1/8])),
-            (Categorical([1/7, 1/7, 2/7, 3/7]), Categorical([1/8, 2/8, 2/8, 3/8]))
+            (Categorical([1 / 4, 1 / 4, 1 / 2]), Categorical([1 / 2, 1 / 8, 3 / 8])),
+            (Categorical([1 / 8, 1 / 8, 3 / 4]), Categorical([1 / 16, 13 / 16, 1 / 8])),
+            (Categorical([1 / 7, 1 / 7, 2 / 7, 3 / 7]), Categorical([1 / 8, 2 / 8, 2 / 8, 3 / 8]))
         ]
         for input_output in inputs_outputs
             m_in = first(input_output)

--- a/test/ext/ReactiveMPProjectionExt/rules/marginals_tests.jl
+++ b/test/ext/ReactiveMPProjectionExt/rules/marginals_tests.jl
@@ -36,7 +36,7 @@
         inputs_outputs = [
             (Binomial(3, 0.9), Binomial(7, 0.4)),
             (Binomial(8, 0.9), Binomial(8, 0.9)),
-            (Binomial(5, 0.01), Binomial(6, 0.98))
+            (Binomial(5, 0.01), Binomial(6, 0.98)),
         ]
         for input_output in inputs_outputs
             m_in = first(input_output)
@@ -48,6 +48,24 @@
             grid = getsupport(q_prod)
             mean_prod = sum(grid .* pdf(q_prod, grid))
             @test mean(component1) ≈ mean_prod atol = 1e-1
+        end
+    end
+
+    @testset "f(x) -> x, x~EF, out~EF with Categorical" begin
+        meta = DeltaMeta(method = CVIProjection(), inverse = nothing)
+        inputs_outputs = [
+            (Categorical([1/4, 1/4, 1/2]), Categorical([1/2, 1/8, 3/8])),
+            (Categorical([1/8, 1/8, 3/4]), Categorical([1/16, 13/16, 1/8])),
+            (Categorical([1/7, 1/7, 2/7, 3/7]), Categorical([1/8, 2/8, 2/8, 3/8]))
+        ]
+        for input_output in inputs_outputs
+            m_in = first(input_output)
+            m_out = last(input_output)
+            q_factorised = @call_marginalrule DeltaFn{identity}(:ins) (m_out = m_out, m_ins = ManyOf(m_in), meta = meta)
+            @test length(q_factorised) === 1
+            component1 = component(q_factorised, 1)
+            q_prod = prod(GenericProd(), m_in, m_out)
+            @test mean(component1) ≈ mean(q_prod) atol = 1e-1
         end
     end
 end


### PR DESCRIPTION
This PR:

1.  Augments the `ProjectedTo` structure with conditioners to in marginal rule computations for delta node. Tests with Binomial and Categorical inputs-outputs.

2. Defines the following products:
 `BayesBase.prod(::GenericProd, something::DivisionOf, division::DivisionOf) ` and `BayesBase.prod(::GenericProd, productof::ProductOf, divisionof::DivisionOf) `.

3. Makes`DivisionOf` structure callable.
