### PR TITLE
remove msg_dep and mar_dep functions

### DIFF
--- a/src/nodes/dependencies.jl
+++ b/src/nodes/dependencies.jl
@@ -111,30 +111,6 @@ end
 
 RequireMessageFunctionalDependencies(; kwargs...) = RequireMessageFunctionalDependencies((; kwargs...))
 
-function message_dependencies(dependencies::RequireMessageFunctionalDependencies, nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
-
-    # First we find dependency index in `indices`, we use it later to find `start_with` distribution
-    depindex = findfirst((i) -> i === iindex, dependencies.indices)
-
-    # If we have `depindex` in our `indices` we include it in our list of functional dependencies. It effectively forces rule to require inbound message
-    if depindex !== nothing
-        # `mapindex` is a lambda function here
-        output     = messagein(nodeinterfaces[iindex])
-        start_with = dependencies.start_with[depindex]
-        # Initialise now, if message has not been initialised before and `start_with` element is not empty
-        if isnothing(getrecent(output)) && !isnothing(start_with)
-            setmessage!(output, start_with)
-        end
-        return map(inds -> map(i -> @inbounds(nodeinterfaces[i]), inds), varcluster)
-    else
-        return message_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
-    end
-end
-
-function marginal_dependencies(::RequireMessageFunctionalDependencies, nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
-    return marginal_dependencies(DefaultFunctionalDependencies(), nodeinterfaces, nodelocalmarginals, varcluster, cindex, iindex)
-end
-
 function functional_dependencies(dependencies::RequireMessageFunctionalDependencies, factornode, interface, iindex)
     specification = dependencies.specification
 


### PR DESCRIPTION
After a discussion with @ThijsvdLaar , we discovered that those 2 functions are only ever used inside themselves, and are not used in any `RxInfer` or `ReactiveMP` tests. I'm not sure if these functions are necessary or if they can be deleted, but it seems that `functional_dependencies` does what these functions were supposed to do.