### PR TITLE
Move the check for `ProductOf` to `RxInfer`

### DIFF
--- a/src/constraints/form.jl
+++ b/src/constraints/form.jl
@@ -82,8 +82,6 @@ default_form_check_strategy(::UnspecifiedFormConstraint) = FormConstraintCheckLa
 default_prod_constraint(::UnspecifiedFormConstraint) = GenericProd()
 
 constrain_form(::UnspecifiedFormConstraint, something) = something
-constrain_form(::UnspecifiedFormConstraint, something::Union{ProductOf, LinearizedProductOf}) =
-    error("`ProductOf` object cannot be used as a functional form in inference backend. Use form constraints to restrict the functional form of marginal posteriors.")
 
 """
     WrappedFormConstraint(constraint, context)

--- a/test/constraints/form_tests.jl
+++ b/test/constraints/form_tests.jl
@@ -7,14 +7,6 @@
     @test constrain_form(UnspecifiedFormConstraint(), MvNormal([0.0, 0.0])) == MvNormal([0.0, 0.0])
 end
 
-@testitem "`UnspecifiedFormConstraint` should error on `ProductOf` and `LinearizedProductOf` objects" begin
-    using Distributions, BayesBase
-    import ReactiveMP: constrain_form
-
-    @test_throws "object cannot be used as a functional form in inference backend" constrain_form(UnspecifiedFormConstraint(), ProductOf(Beta(1, 1), Normal(0, 1)))
-    @test_throws "object cannot be used as a functional form in inference backend" constrain_form(UnspecifiedFormConstraint(), LinearizedProductOf([Beta(1, 1), Beta(1, 1)], 2))
-end
-
 @testitem "`CompositeFormConstraint` should call the constraints in the specified order" begin
     import ReactiveMP: constrain_form
 


### PR DESCRIPTION
This is a part of https://github.com/ReactiveBayes/RxInfer.jl/issues/335
The associated RxInfer PR is https://github.com/ReactiveBayes/RxInfer.jl/pull/347