### PR TITLE
fix #434: determine threads/cores via extra package Hwloc, if CpuId fails

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -90,17 +90,18 @@ DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExponentialFamilyProjection = "17f509fa-9a96-44ba-99b2-1c5f01f0931b"
+Hwloc = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
-ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [targets]
-test = ["Aqua", "CpuId", "ReTestItems", "Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "JET", "PkgBenchmark", "StableRNGs", "Optimisers", "DiffResults", "ExponentialFamilyProjection", "REPL"]
+test = ["Aqua", "CpuId", "Hwloc", "ReTestItems", "Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "JET", "PkgBenchmark", "StableRNGs", "Optimisers", "DiffResults", "ExponentialFamilyProjection", "REPL"]

--- a/Project.toml
+++ b/Project.toml
@@ -84,7 +84,6 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
-CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -104,4 +103,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [targets]
-test = ["Aqua", "CpuId", "Hwloc", "ReTestItems", "Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "JET", "PkgBenchmark", "StableRNGs", "Optimisers", "DiffResults", "ExponentialFamilyProjection", "REPL"]
+test = ["Aqua", "Hwloc", "ReTestItems", "Test", "Pkg", "Logging", "InteractiveUtils", "TestSetExtensions", "Coverage", "Dates", "Distributed", "Documenter", "BenchmarkCI", "BenchmarkTools", "JET", "PkgBenchmark", "StableRNGs", "Optimisers", "DiffResults", "ExponentialFamilyProjection", "REPL"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,8 @@
-using Aqua, CpuId, ReTestItems, ReactiveMP, Hwloc
+using Aqua, ReTestItems, ReactiveMP, Hwloc
 
 Aqua.test_all(ReactiveMP; ambiguities = false, piracies = false, deps_compat = (; check_extras = false, check_weakdeps = true))
 
-nthreads, ncores = cputhreads(), cpucores()
-nthreads = nthreads == 0 ? Hwloc.num_virtual_cores() : nthreads
-ncores = ncores == 0 ? Hwloc.num_physical_cores() : ncores
+nthreads, ncores = Hwloc.num_virtual_cores(), Hwloc.num_physical_cores()
 nthreads, ncores = max(nthreads, 1), max(ncores, 1)
 
 runtests(ReactiveMP; nworkers = ncores, nworker_threads = Int(nthreads / ncores), memory_threshold = 1.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
-using Aqua, CpuId, ReTestItems, ReactiveMP
+using Aqua, CpuId, ReTestItems, ReactiveMP, Hwloc
 
 Aqua.test_all(ReactiveMP; ambiguities = false, piracies = false, deps_compat = (; check_extras = false, check_weakdeps = true))
 
-nthreads = max(cputhreads(), 1)
-ncores = max(cpucores(), 1)
+nthreads, ncores = cputhreads(), cpucores()
+nthreads = nthreads == 0 ? Hwloc.num_virtual_cores() : nthreads
+ncores = ncores == 0 ? Hwloc.num_physical_cores() : ncores
+nthreads, ncores = max(nthreads, 1), max(ncores, 1)
 
 runtests(ReactiveMP; nworkers = ncores, nworker_threads = Int(nthreads / ncores), memory_threshold = 1.0)


### PR DESCRIPTION
This PR should fix #434 .

Let me know if I need to add a test for this? It works now locally and Hwloc only triggers if CpuId fails (which is only in the case of ARM machines).

As soon as this works, I'll update the runtests.jl in the other packages accordingly.