### PR TITLE
Enhance functional dependencies customization in ReactiveMP

### DIFF
--- a/docs/src/lib/nodes.md
+++ b/docs/src/lib/nodes.md
@@ -1,4 +1,3 @@
-
 # [Nodes implementation](@id lib-node)
 
 In the message passing framework, one of the most important concepts is a factor node.
@@ -100,7 +99,11 @@ Here we see that in the standard setting for the belief-propagation message out 
 \mu(x) = \exp \int q(y) q(z) \log f(x, y, z) \mathrm{d}y \mathrm{d}z
 ```
 
-We see that in this setting, we do not need messages $\mu(y)$ and $\mu(z)$, but only the marginals $q(y)$ and $q(z)$. The purpose of a __functional dependencies pipeline__ is to determine functional dependencies (a set of messages or marginals) that are needed to compute a single message. By default, `ReactiveMP.jl` uses so-called `DefaultFunctionalDependencies` that correctly implements belief-propagation and variational message passing schemes (including both mean-field and structured factorisations). The full list of built-in pipelines is presented below:
+We see that in this setting, we do not need messages $\mu(y)$ and $\mu(z)$, but only the marginals $q(y)$ and $q(z)$. 
+
+## [List of functional dependencies pipelines](@id lib-node-functional-dependencies-pipelines)
+
+The purpose of a __functional dependencies pipeline__ is to determine functional dependencies (a set of messages or marginals) that are needed to compute a single message. By default, `ReactiveMP.jl` uses so-called `DefaultFunctionalDependencies` that correctly implements belief-propagation and variational message passing schemes (including both mean-field and structured factorisations). The full list of built-in pipelines is presented below:
 
 ```@docs
 ReactiveMP.DefaultFunctionalDependencies
@@ -108,6 +111,27 @@ ReactiveMP.RequireMessageFunctionalDependencies
 ReactiveMP.RequireMarginalFunctionalDependencies
 ReactiveMP.RequireEverythingFunctionalDependencies
 ```
+
+## [Customizing Dependencies with Metadata](@id lib-node-metadata-dependencies)
+
+The functional dependencies of a node can be customized at runtime using options during node activation. This allows for runtime customization of the functional dependencies, e.g. to test different message passing schemes or implement specialized behavior for specific instances of a node type:
+
+```julia
+# Define custom dependencies based on metadata
+function ReactiveMP.collect_functional_dependencies(::Type{MyNode}, options::FactorNodeActivationOptions)
+    if some_condition(options) # a user can specify dependencies based, for example, on metadata
+        return CustomDependencies()
+    end
+    # Fall back to default dependencies
+    return ReactiveMP.collect_functional_dependencies(MyNode, getdependecies(options))
+end
+
+# Use custom dependencies during activation
+node = factornode(MyNode, ...)
+activate!(node, FactorNodeActivationOptions(:custom_behavior, ...))
+```
+
+This feature is particularly useful for testing different message passing schemes or implementing specialized behavior for specific instances of a node type.
 
 ## [Node traits](@id lib-node-traits)
 

--- a/src/nodes/nodes.jl
+++ b/src/nodes/nodes.jl
@@ -260,8 +260,11 @@ getaddons(options::FactorNodeActivationOptions) = options.addons
 getscheduler(options::FactorNodeActivationOptions) = options.scheduler
 getrulefallback(options::FactorNodeActivationOptions) = options.rulefallback
 
+# Users can override the dependencies if they want to
+collect_functional_dependencies(fform::F, options::FactorNodeActivationOptions) where {F} = collect_functional_dependencies(fform, getdependecies(options))
+
 function activate!(factornode::FactorNode, options::FactorNodeActivationOptions)
-    dependencies = collect_functional_dependencies(functionalform(factornode), getdependecies(options))
+    dependencies = collect_functional_dependencies(functionalform(factornode), options)
     initialize_clusters!(getlocalclusters(factornode), dependencies, factornode, options)
     return activate!(dependencies, factornode, options)
 end

--- a/test/nodes/dependencies_tests.jl
+++ b/test/nodes/dependencies_tests.jl
@@ -511,6 +511,5 @@ end
         msg_deps_b, marg_deps_b = functional_dependencies(deps_b, node_b, out_interface_b, 1)
         @test length(msg_deps_b) == 1
         @test name(first(msg_deps_b)) === :in2
-        
     end
 end


### PR DESCRIPTION
This PR fixes #436 

This pull request include updates to the `ReactiveMP` library documentation and functionality, focusing on the customization of functional dependencies for nodes. The changes enhance the documentation, add new features for runtime customization, and includes tests to ensure the new functionality works as intended.

Users now can specify
```julia
function ReactiveMP.collect_functional_dependencies(::Type{CustomNode}, options::FactorNodeActivationOptions)
    # custom behaviour
end
```
to set functional dependencies in runtime. `options` has an access to various settings, including metadata as requested in the original issue.