### PR TITLE
Add message for y interface of Binomial Polya

### DIFF
--- a/src/rules/binomial_polya/y.jl
+++ b/src/rules/binomial_polya/y.jl
@@ -1,0 +1,17 @@
+using PolyaGammaHybridSamplers
+using ExponentialFamily.LogExpFunctions
+@rule BinomialPolya(:y, Marginalisation) (q_x::PointMass, q_n::PointMass, q_β::GaussianDistributionsFamily, meta::Union{BinomialPolyaMeta, Nothing}) = begin
+    x = mean(q_x)
+    n = mean(q_n)
+    if isnothing(meta)
+        β = mean(q_β)
+        ψ = dot(x, β)
+        p = logistic(ψ)
+        return Binomial(n, p)
+    else
+        n_samples = getn_samples(meta)
+        βsamples = rand(meta.rng, q_β, n_samples)
+        p_avg = mapreduce(βsample -> logistic(dot(x, βsample)), +, eachcol(βsamples))/n_samples
+        return Binomial(n, p_avg)
+    end
+end

--- a/src/rules/predefined.jl
+++ b/src/rules/predefined.jl
@@ -185,6 +185,7 @@ include("delta/cvi/marginals.jl")
 include("half_normal/out.jl")
 
 include("binomial_polya/beta.jl")
+include("binomial_polya/y.jl")
 
 include("tensor_dirichlet/out.jl")
 include("tensor_dirichlet/marginals.jl")

--- a/test/rules/binomial_polya/y_tests.jl
+++ b/test/rules/binomial_polya/y_tests.jl
@@ -1,0 +1,28 @@
+@testitem "rules:BinomialPolya:beta" begin
+    using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions, PolyaGammaHybridSamplers
+
+    import ReactiveMP: @test_rules, weightedmean
+    import LinearAlgebra: diag
+
+    @testset "Predictive Distribution" begin
+        q_x = PointMass([0.1, 0.2])
+        q_n = PointMass(5)
+        q_β = MvNormalWeightedMeanPrecision([3.0, -1.0], diageye(2))
+        
+        # Test with default meta
+        pred_dist = @call_rule BinomialPolya(:y, Marginalisation) (q_x = q_x, q_n = q_n, q_β = q_β, meta = nothing)
+        @test pred_dist isa Binomial
+        @test ntrials(pred_dist) == 5
+        
+        # Test with Monte Carlo sampling
+        meta = BinomialPolyaMeta(1000, MersenneTwister(42))
+        pred_dist_mc = @call_rule BinomialPolya(:y, Marginalisation) (q_x = q_x, q_n = q_n, q_β = q_β, meta = meta)
+        @test pred_dist_mc isa Binomial
+        @test ntrials(pred_dist_mc) == 5
+        @test 0 < succprob(pred_dist_mc) < 1
+
+        @test pred_dist_mc.p ≈ pred_dist.p atol = 1e-2
+    end
+
+end
+


### PR DESCRIPTION
Add predictive distribution for BinomialPolya node

This PR implements the predictive distribution for the BinomialPolya node using Pólya-Gamma augmentation. The implementation includes:

- Message passing rule for predictive distribution 
- Support for both analytical and Monte Carlo approximations

Key features:
- Analytical approximation using mean of β when meta is nothing
- Monte Carlo sampling with configurable number of samples when meta is provided
- Returns Binomial distribution with averaged success probability

Files changed:
- src/rules/binomial_polya/y.jl: Added predictive distribution rule
- test/rules/binomial_polya/y_tests.jl: Tests