### PR TITLE
Improve documentation and error handling `Mixture` node

### DIFF
--- a/src/addons/logscale.jl
+++ b/src/addons/logscale.jl
@@ -11,11 +11,12 @@ end
 AddonLogScale() = AddonLogScale(nothing)
 
 getlogscale(addon::AddonLogScale) = addon.logscale
+getlogscale(::Nothing) = error("Log-scale addon is not available. Make sure to include AddonLogScale in the addons. Currently, log scale factors are only supported for very specific nodes and messages in sum-product updates. Extensions to variational message passing are not yet supported.")
 
 function getlogscale(addons::NTuple{N, AbstractAddon}) where {N}
     logscales = filter(addon -> addon isa AddonLogScale, addons)
     if length(logscales) === 0
-        error("Log-scale addon is not available.")
+        error("Log-scale addon is not available. Make sure to include AddonLogScale in the addons.")
     end
     return mapreduce(getlogscale, +, logscales)
 end

--- a/src/nodes/predefined/mixture.jl
+++ b/src/nodes/predefined/mixture.jl
@@ -14,6 +14,34 @@ collect_factorisation(::Type{<:Mixture}, factorization) = MixtureNodeFactorisati
 struct MixtureNodeFactorisation end
 
 struct MixtureNode{N} <: AbstractFactorNode
+    """
+        MixtureNode{N}
+
+    A factor node that represents a mixture model with N components that under the hood performs Bayesian model comparison.
+
+    # Interfaces
+    - `:out`: The output interface representing the mixture distribution
+    - `:switch`: The switch interface representing the mixture weights (e.g. Categorical distribution)
+    - `:inputs`: The N component interfaces representing the mixture components
+
+    # Example
+    ```julia
+    # Create a mixture of 2 Gaussians
+    @model function mixture_model()
+        # Switch variable (mixture weights)
+        s ~ Categorical([0.3, 0.7]) 
+        
+        # Component distributions
+        c1 ~ Normal(0.0, 1.0)
+        c2 ~ Normal(5.0, 1.0)
+        
+        # Mixture node connecting components
+        y ~ Mixture(s, [c1, c2])
+    end
+    ```
+
+    Note: The `Mixture` node requires the `AddonLogScale` addon to be included in the addons. However, this addon is not available for most message update rules. Only for certain sum-product update rules these are included. For a detailed explanation on the `Mixture` node see the [Mixture node paper](https://www.mdpi.com/1099-4300/25/8/1138).
+    """
     out    :: NodeInterface
     switch :: NodeInterface
     inputs :: NTuple{N, IndexedNodeInterface}


### PR DESCRIPTION
This pull request includes minor changes to the `src/addons/logscale.jl` and `src/nodes/predefined/mixture.jl` files to enhance error messaging and documentation. The most important changes include adding a more detailed error message for missing log-scale addons and providing comprehensive documentation for the `MixtureNode` struct.

Enhancements to error messaging:

* [`src/addons/logscale.jl`](diffhunk://#diff-cf5cd4484415dd0cd42936b8ab870c2da582c5bc69cbd27f73df38956bff6762R14-R19): Added a detailed error message for cases where the log-scale addon is not available, guiding users to include `AddonLogScale` in the addons.

Improvements to documentation:

* [`src/nodes/predefined/mixture.jl`](diffhunk://#diff-8ea0b75616b7d1e1d6bcf53553bb74bcb458aae57c327b9061616632f1c9f4a5R17-R44): Added extensive documentation for the `MixtureNode{N}` struct, including a description of its interfaces, an example usage, and a note on the requirement of the `AddonLogScale` addon.