### PR TITLE
Relax rules for softdot and autoregressive rules

### DIFF
--- a/src/rules/autoregressive/gamma.jl
+++ b/src/rules/autoregressive/gamma.jl
@@ -1,5 +1,5 @@
 
-@rule AR(:γ, Marginalisation) (q_y_x::MultivariateNormalDistributionsFamily, q_θ::NormalDistributionsFamily, meta::ARMeta) = begin
+@rule AR(:γ, Marginalisation) (q_y_x::MultivariateNormalDistributionsFamily, q_θ::Any, meta::ARMeta) = begin
     order = getorder(meta)
     F     = getvform(meta)
 

--- a/src/rules/autoregressive/marginals.jl
+++ b/src/rules/autoregressive/marginals.jl
@@ -1,9 +1,9 @@
 
-@marginalrule AR(:y_x) (m_y::NormalDistributionsFamily, m_x::NormalDistributionsFamily, q_θ::NormalDistributionsFamily, q_γ::Any, meta::ARMeta) = begin
+@marginalrule AR(:y_x) (m_y::Any, m_x::Any, q_θ::Any, q_γ::Any, meta::ARMeta) = begin
     return ar_y_x_marginal(getstype(meta), m_y, m_x, q_θ, q_γ, meta)
 end
 
-function ar_y_x_marginal(::ARsafe, m_y::NormalDistributionsFamily, m_x::NormalDistributionsFamily, q_θ::NormalDistributionsFamily, q_γ::Any, meta::ARMeta)
+function ar_y_x_marginal(::ARsafe, m_y::Any, m_x::Any, q_θ::Any, q_γ::Any, meta::ARMeta)
     mθ, Vθ = mean_cov(q_θ)
     mγ = mean(q_γ)
 
@@ -34,7 +34,7 @@ function ar_y_x_marginal(::ARsafe, m_y::NormalDistributionsFamily, m_x::NormalDi
     return MvNormalWeightedMeanPrecision(ξ, W)
 end
 
-function ar_y_x_marginal(::ARunsafe, m_y::NormalDistributionsFamily, m_x::NormalDistributionsFamily, q_θ::NormalDistributionsFamily, q_γ::Any, meta::ARMeta)
+function ar_y_x_marginal(::ARunsafe, m_y::Any, m_x::Any, q_θ::Any, q_γ::Any, meta::ARMeta)
     mθ, Vθ = mean(q_θ), cov(q_θ)
 
     mA = as_companion_matrix(mθ)

--- a/src/rules/autoregressive/x.jl
+++ b/src/rules/autoregressive/x.jl
@@ -1,5 +1,5 @@
 
-@rule AR(:x, Marginalisation) (m_y::NormalDistributionsFamily, q_θ::NormalDistributionsFamily, q_γ::Any, meta::ARMeta) = begin
+@rule AR(:x, Marginalisation) (m_y::Any, q_θ::Any, q_γ::Any, meta::ARMeta) = begin
     mθ, Vθ = mean_cov(q_θ)
     my, Vy = mean_cov(m_y)
 

--- a/src/rules/autoregressive/y.jl
+++ b/src/rules/autoregressive/y.jl
@@ -1,5 +1,5 @@
 
-@rule AR(:y, Marginalisation) (m_x::NormalDistributionsFamily, q_θ::NormalDistributionsFamily, q_γ::Any, meta::ARMeta) = begin
+@rule AR(:y, Marginalisation) (m_x::Any, q_θ::Any, q_γ::Any, meta::ARMeta) = begin
     mθ, Vθ = mean_cov(q_θ)
     mx, Wx = mean_invcov(m_x)
 

--- a/src/rules/softdot/marginals.jl
+++ b/src/rules/softdot/marginals.jl
@@ -1,6 +1,6 @@
 
 # The following marginal rule is adaptation of the marginal rule for Autoregressive node
-@marginalrule SoftDot(:y_x) (m_y::NormalDistributionsFamily, m_x::NormalDistributionsFamily, q_θ::NormalDistributionsFamily, q_γ::Any) = begin
+@marginalrule SoftDot(:y_x) (m_y::Any, m_x::Any, q_θ::Any, q_γ::Any) = begin
     mθ, Vθ = mean_cov(q_θ)
     mγ = mean(q_γ)
 

--- a/src/rules/softdot/x.jl
+++ b/src/rules/softdot/x.jl
@@ -11,7 +11,7 @@
 end
 
 # Variational MP: Structured
-@rule softdot(:x, Marginalisation) (m_y::UnivariateNormalDistributionsFamily, q_θ::Any, q_γ::Any) = begin
+@rule softdot(:x, Marginalisation) (m_y::Any, q_θ::Any, q_γ::Any) = begin
     # the naive call of AR rule is not possible, because the softdot rule expects m_y to be a UnivariateNormalDistributionsFamily
     mθ, Vθ = mean_cov(q_θ)
     my, Vy = mean_cov(m_y)


### PR DESCRIPTION
This PR relaxes the requirement for the input types on AR and SoftDot rules.