### PR TITLE
fix: softdot average energy

### DIFF
--- a/src/nodes/predefined/softdot.jl
+++ b/src/nodes/predefined/softdot.jl
@@ -2,27 +2,7 @@ export softdot, SoftDot
 
 import StatsFuns: log2π
 
-"""
-SoftDot [aliases = [softdot]]: ReactiveMP node for message passing. 
-
-The SoftDot node can be used as a substitute for the dot product operator delta node (the outgoing variable is the dot product of two others). It softens the delta constraint by adding a Gaussian noise as follows:
-
-    y ~ N(dot(θ, x), γ^(-1))
-
-Interfaces:
-1. y - result of the "soft" dot product,
-2. θ - first variable to be multiplied,
-3. x - second variable to be multiplied,
-4. γ - precision of the Gaussian noise.
-
-The advantage of using SoftDot is that it offers tractable and optimized closed-form variational messages 
-for both Belief Propagation and Variational Message Passing.
-"""
 struct SoftDot end
-
-"""
-Alias for the `SoftDot` node.
-"""
 const softdot = SoftDot
 
 @node softdot Stochastic [y, (θ, aliases = [theta]), x, (γ, aliases = [gamma])]
@@ -42,10 +22,9 @@ end
 
     order = length(mθ)
     F     = order == 1 ? Univariate : Multivariate
-
-    mx, Vx   = ar_slice(F, myx, (order + 1):(2order)), ar_slice(F, Vyx, (order + 1):(2order), (order + 1):(2order))
+    mx, Vx   = ar_slice(F, myx, (2):(order+1)), ar_slice(F, Vyx, (2):(order+1), (2):(order+1))
     my1, Vy1 = first(myx), first(Vyx)
-    Vy1x     = ar_slice(F, Vyx, 1, (order + 1):(2order))
+    Vy1x     = ar_slice(F, Vyx, 1, (2):(order+1))
 
     # Equivalent to AE = (-mean(log, q_γ) + log2π + mγ*(Vy1+my1^2 - 2*mθ'*(Vy1x + mx*my1) + tr(Vθ*Vx) + mx'*Vθ*mx + mθ'*(Vx + mx*mx')*mθ)) / 2
     AE = (-mean(log, q_γ) + log2π + mγ * (Vy1 + my1^2 - 2 * mθ' * (Vy1x + mx * my1) + mul_trace(Vθ, Vx) + dot(mx, Vθ, mx) + dot(mθ, Vx, mθ) + abs2(dot(mθ, mx)))) / 2

--- a/src/nodes/predefined/softdot.jl
+++ b/src/nodes/predefined/softdot.jl
@@ -1,8 +1,30 @@
 export softdot, SoftDot
 
 import StatsFuns: log2π
+"""
+    SoftDot
+    
+The SoftDot node can be used as a substitute for the dot product operator delta node (the outgoing variable is the dot product of two others). 
+It softens the delta constraint by adding a Gaussian noise as follows:
 
+    y ~ N(dot(θ, x), γ^(-1))
+
+Interfaces:
+1. y - result of the "soft" dot product,
+2. θ - first variable to be multiplied,
+3. x - second variable to be multiplied,
+4. γ - precision of the Gaussian noise.
+
+The advantage of using SoftDot is that it offers tractable and optimized closed-form variational messages 
+for both Belief Propagation and Variational Message Passing.
+
+See also: [`softdot`](@ref)
+"""
 struct SoftDot end
+
+"""
+Alias for the `SoftDot` node.
+"""
 const softdot = SoftDot
 
 @node softdot Stochastic [y, (θ, aliases = [theta]), x, (γ, aliases = [gamma])]

--- a/src/nodes/predefined/softdot.jl
+++ b/src/nodes/predefined/softdot.jl
@@ -20,11 +20,11 @@ end
     myx, Vyx = mean_cov(q_y_x)
     mγ       = mean(q_γ)
 
-    order = length(mθ)
-    F     = order == 1 ? Univariate : Multivariate
-    mx, Vx   = ar_slice(F, myx, (2):(order+1)), ar_slice(F, Vyx, (2):(order+1), (2):(order+1))
+    order    = length(mθ)
+    F        = order == 1 ? Univariate : Multivariate
+    mx, Vx   = ar_slice(F, myx, (2):(order + 1)), ar_slice(F, Vyx, (2):(order + 1), (2):(order + 1))
     my1, Vy1 = first(myx), first(Vyx)
-    Vy1x     = ar_slice(F, Vyx, 1, (2):(order+1))
+    Vy1x     = ar_slice(F, Vyx, 1, (2):(order + 1))
 
     # Equivalent to AE = (-mean(log, q_γ) + log2π + mγ*(Vy1+my1^2 - 2*mθ'*(Vy1x + mx*my1) + tr(Vθ*Vx) + mx'*Vθ*mx + mθ'*(Vx + mx*mx')*mθ)) / 2
     AE = (-mean(log, q_γ) + log2π + mγ * (Vy1 + my1^2 - 2 * mθ' * (Vy1x + mx * my1) + mul_trace(Vθ, Vx) + dot(mx, Vθ, mx) + dot(mθ, Vx, mθ) + abs2(dot(mθ, mx)))) / 2

--- a/test/nodes/predefined/softdot_tests.jl
+++ b/test/nodes/predefined/softdot_tests.jl
@@ -33,7 +33,7 @@
         end
 
         begin
-            q_y_x = MvNormalMeanCovariance(zeros(4), diageye(4))
+            q_y_x = MvNormalMeanCovariance(zeros(3), diageye(3))
             q_θ = MvNormalMeanCovariance([0.0, 0.0], [1.0 0.0; 0.0 1.0])
             q_γ = GammaShapeRate(2.0, 3.0)
 

--- a/test/nodes/predefined/softdot_tests.jl
+++ b/test/nodes/predefined/softdot_tests.jl
@@ -32,7 +32,6 @@
             @test score(AverageEnergy(), SoftDot, Val{(:y_x, :θ, :γ)}(), marginals, nothing) ≈ 1.92351917665616
         end
 
-
         begin
             q_y_x = MvNormalMeanCovariance(zeros(4), diageye(4))
             q_θ = MvNormalMeanCovariance([0.0, 0.0], [1.0 0.0; 0.0 1.0])

--- a/test/nodes/predefined/softdot_tests.jl
+++ b/test/nodes/predefined/softdot_tests.jl
@@ -31,5 +31,15 @@
             marginals = (Marginal(q_y_x, false, false, nothing), Marginal(q_θ, false, false, nothing), Marginal(q_γ, false, false, nothing))
             @test score(AverageEnergy(), SoftDot, Val{(:y_x, :θ, :γ)}(), marginals, nothing) ≈ 1.92351917665616
         end
+
+
+        begin
+            q_y_x = MvNormalMeanCovariance(zeros(4), diageye(4))
+            q_θ = NormalMeanVariance(0.0, 1.0)
+            q_γ = GammaShapeRate(2.0, 3.0)
+
+            marginals = (Marginal(q_y_x, false, false, nothing), Marginal(q_θ, false, false, nothing), Marginal(q_γ, false, false, nothing))
+            @test score(AverageEnergy(), SoftDot, Val{(:y_x, :θ, :γ)}(), marginals, nothing) ≈ 1.92351917665616
+        end
     end # testset: AverageEnergy
 end # testset

--- a/test/nodes/predefined/softdot_tests.jl
+++ b/test/nodes/predefined/softdot_tests.jl
@@ -35,11 +35,11 @@
 
         begin
             q_y_x = MvNormalMeanCovariance(zeros(4), diageye(4))
-            q_θ = NormalMeanVariance(0.0, 1.0)
+            q_θ = MvNormalMeanCovariance([0.0, 0.0], [1.0 0.0; 0.0 1.0])
             q_γ = GammaShapeRate(2.0, 3.0)
 
             marginals = (Marginal(q_y_x, false, false, nothing), Marginal(q_θ, false, false, nothing), Marginal(q_γ, false, false, nothing))
-            @test score(AverageEnergy(), SoftDot, Val{(:y_x, :θ, :γ)}(), marginals, nothing) ≈ 1.92351917665616
+            @test score(AverageEnergy(), SoftDot, Val{(:y_x, :θ, :γ)}(), marginals, nothing) ≈ 2.256852 atol = 1e-4
         end
     end # testset: AverageEnergy
 end # testset


### PR DESCRIPTION
In the current average energy computation for the softdot node under structured factorization assumption the indices in the following line `ar_slice(F, myx, (order + 1):(2order)), ar_slice(F, Vyx, (order + 1):(2order), (order + 1):(2order))` are inaccurate. Suppose x is 2d and \theta is also 2d. Then y is 1d. Meaning order is 2 in this case. In this example then the slice will range between 3:4 causing bounds error. This PR attempts to resolve this issue.