### PR TITLE
Tighten the dispatch for the ruleset for DiscreteTransition

### DIFF
--- a/src/nodes/predefined/discrete_transition.jl
+++ b/src/nodes/predefined/discrete_transition.jl
@@ -37,7 +37,7 @@ end
     return -tr(components(q_out_in)' * mean(BroadcastFunction(log), q_a))
 end
 
-@average_energy DiscreteTransition (q_out_in::Contingency, q_a::PointMass) = begin
+@average_energy DiscreteTransition (q_out_in::Contingency, q_a::PointMass{<:AbstractArray{T, 2}}) where {T} = begin
     # `map(clamplog, mean(q_a))` is an equivalent of `mean(BroadcastFunction(log), q_a)` with an extra `clamp(el, tiny, Inf)` operation
     # The reason is that we don't want to take log of zeros in the matrix `q_a` (if there are any)
     # The trick here is that if RHS matrix has zero inputs, than the corresponding entries of the `contingency_matrix` matrix 
@@ -46,7 +46,7 @@ end
     return result
 end
 
-@average_energy DiscreteTransition (q_out::Any, q_in::Any, q_a::PointMass) = begin
+@average_energy DiscreteTransition (q_out::Any, q_in::Any, q_a::PointMass{<:AbstractArray{T, 2}}) where {T} = begin
     return -probvec(q_out)' * mean(BroadcastFunction(clamplog), q_a) * probvec(q_in)
 end
 
@@ -59,7 +59,9 @@ function score(
     ::AverageEnergy,
     ::Type{<:DiscreteTransition},
     ::Val{mnames},
-    marginals::NTuple{N, Union{<:Marginal{Bernoulli}, <:Marginal{Categorical}, <:Marginal{<:Contingency}, <:Marginal{<:DirichletCollection}, <:Marginal{<:PointMass}}},
+    marginals::NTuple{
+        N, Union{<:Marginal{Bernoulli}, <:Marginal{Categorical}, <:Marginal{<:Contingency}, <:Marginal{<:DirichletCollection}, <:Marginal{<:PointMass{<:AbstractArray}}}
+    },
     ::Any
 ) where {mnames, N}
     q_a = marginals[findfirst(==(:a), mnames)]

--- a/src/rules/discrete_transition/categoricals.jl
+++ b/src/rules/discrete_transition/categoricals.jl
@@ -173,7 +173,9 @@ function ReactiveMP.rule(
     messages_names::Val{mes_names},
     messages::NTuple{N, Union{Message{<:PointMass}, Message{<:DiscreteNonParametric}}},
     marginals_names::Val{mar_names},
-    marginals::NTuple{M, Union{Marginal{<:DirichletCollection}, Marginal{<:PointMass}, Marginal{<:DiscreteNonParametric}, Marginal{<:Contingency}, Marginal{<:Bernoulli}}},
+    marginals::NTuple{
+        M, Union{Marginal{<:DirichletCollection}, Marginal{<:PointMass{<:AbstractArray}}, Marginal{<:DiscreteNonParametric}, Marginal{<:Contingency}, Marginal{<:Bernoulli}}
+    },
     meta::Any,
     addons::Any,
     ::Any
@@ -189,7 +191,9 @@ function ReactiveMP.rule(
     messages_names::Nothing,
     messages::Nothing,
     marginals_names::Val{mar_names},
-    marginals::NTuple{M, Union{Marginal{<:DirichletCollection}, Marginal{<:PointMass}, Marginal{<:DiscreteNonParametric}, Marginal{<:Contingency}, Marginal{<:Bernoulli}}},
+    marginals::NTuple{
+        M, Union{Marginal{<:DirichletCollection}, Marginal{<:PointMass{<:AbstractArray}}, Marginal{<:DiscreteNonParametric}, Marginal{<:Contingency}, Marginal{<:Bernoulli}}
+    },
     meta::Any,
     addons::Any,
     ::Any

--- a/src/rules/discrete_transition/predefined/belief_propagation.jl
+++ b/src/rules/discrete_transition/predefined/belief_propagation.jl
@@ -1,13 +1,13 @@
 using Tullio
 
 # --------------- Rules for 2 interfaces (PointMass q_a) ---------------
-@rule DiscreteTransition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:out, Marginalisation) (m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 2}}, meta::Any) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[i, a] * probvec(m_in)[a]
     return Categorical(normalize!(out, 1))
 end
 
-@rule DiscreteTransition(:in, Marginalisation) (m_out::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (m_out::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 2}}, meta::Any) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, i] * probvec(m_out)[a]
     return Categorical(normalize!(out, 1))
@@ -27,19 +27,19 @@ end
 end
 
 # --------------- Rules for 3 interfaces (PointMass q_a) ---------------
-@rule DiscreteTransition(:out, Marginalisation) (m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:out, Marginalisation) (m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 3}}, meta::Any) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[i, a, b] * probvec(m_in)[a] * probvec(m_T1)[b]
     return Categorical(normalize!(out, 1))
 end
 
-@rule DiscreteTransition(:in, Marginalisation) (m_out::DiscreteNonParametric, m_T1::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (m_out::DiscreteNonParametric, m_T1::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 3}}, meta::Any) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, i, b] * probvec(m_out)[a] * probvec(m_T1)[b]
     return Categorical(normalize!(out, 1))
 end
 
-@rule DiscreteTransition(:T1, Marginalisation) (m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:T1, Marginalisation) (m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 3}}, meta::Any) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, b, i] * probvec(m_out)[a] * probvec(m_in)[b]
     return Categorical(normalize!(out, 1))
@@ -65,25 +65,33 @@ end
 end
 
 # --------------- Rules for 4 interfaces (PointMass q_a) ---------------
-@rule DiscreteTransition(:out, Marginalisation) (m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:out, Marginalisation) (
+    m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 4}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[i, a, b, c] * probvec(m_in)[a] * probvec(m_T1)[b] * probvec(m_T2)[c]
     return Categorical(normalize!(out, 1))
 end
 
-@rule DiscreteTransition(:in, Marginalisation) (m_out::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (
+    m_out::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 4}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, i, b, c] * probvec(m_out)[a] * probvec(m_T1)[b] * probvec(m_T2)[c]
     return Categorical(normalize!(out, 1))
 end
 
-@rule DiscreteTransition(:T1, Marginalisation) (m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:T1, Marginalisation) (
+    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 4}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, b, i, c] * probvec(m_out)[a] * probvec(m_in)[b] * probvec(m_T2)[c]
     return Categorical(normalize!(out, 1))
 end
 
-@rule DiscreteTransition(:T2, Marginalisation) (m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:T2, Marginalisation) (
+    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 4}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, b, c, i] * probvec(m_out)[a] * probvec(m_in)[b] * probvec(m_T1)[c]
     return Categorical(normalize!(out, 1))
@@ -116,40 +124,40 @@ end
 
 # --------------- Rules for 5 interfaces (PointMass q_a) ---------------
 @rule DiscreteTransition(:out, Marginalisation) (
-    m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, q_a::PointMass, meta::Any
-) = begin
+    m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[i, a, b, c, d] * probvec(m_in)[a] * probvec(m_T1)[b] * probvec(m_T2)[c] * probvec(m_T3)[d]
     return Categorical(normalize!(out, 1))
 end
 
 @rule DiscreteTransition(:in, Marginalisation) (
-    m_out::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, q_a::PointMass, meta::Any
-) = begin
+    m_out::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, i, b, c, d] * probvec(m_out)[a] * probvec(m_T1)[b] * probvec(m_T2)[c] * probvec(m_T3)[d]
     return Categorical(normalize!(out, 1))
 end
 
 @rule DiscreteTransition(:T1, Marginalisation) (
-    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, q_a::PointMass, meta::Any
-) = begin
+    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, b, i, c, d] * probvec(m_out)[a] * probvec(m_in)[b] * probvec(m_T2)[c] * probvec(m_T3)[d]
     return Categorical(normalize!(out, 1))
 end
 
 @rule DiscreteTransition(:T2, Marginalisation) (
-    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass, meta::Any
-) = begin
+    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, b, c, i, d] * probvec(m_out)[a] * probvec(m_in)[b] * probvec(m_T1)[c] * probvec(m_T2)[d]
     return Categorical(normalize!(out, 1))
 end
 
 @rule DiscreteTransition(:T3, Marginalisation) (
-    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass, meta::Any
-) = begin
+    m_out::DiscreteNonParametric, m_in::DiscreteNonParametric, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, meta::Any
+) where {T} = begin
     eloga = mean(q_a)
     @tullio out[i] := eloga[a, b, c, d, i] * probvec(m_out)[a] * probvec(m_in)[b] * probvec(m_T1)[c] * probvec(m_T2)[d]
     return Categorical(normalize!(out, 1))

--- a/src/rules/discrete_transition/predefined/structured_vmp.jl
+++ b/src/rules/discrete_transition/predefined/structured_vmp.jl
@@ -1,7 +1,7 @@
 using Tullio
 
 # --------------- Rules for 2 interfaces (q_out PointMass) ---------------
-@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass{<:AbstractVector}, q_a::PointMass{<:AbstractArray{T, 2}}, meta::Any) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i] := eloga[a, i] * probvec(q_out)[a]
     out = exp.(out)
@@ -9,7 +9,7 @@ using Tullio
 end
 
 # --------------- Rules for 2 interfaces (q_out PointMass, q_a DirichletCollection) ---------------
-@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass, q_a::DirichletCollection, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass{<:AbstractVector}, q_a::DirichletCollection, meta::Any) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i] := eloga[a, i] * probvec(q_out)[a]
     out = exp.(out)
@@ -17,7 +17,7 @@ end
 end
 
 # --------------- Rules for 3 interfaces (q_out PointMass, q_a PointMass) ---------------
-@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass, q_a::PointMass, m_T1::DiscreteNonParametric, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass{<:AbstractVector}, q_a::PointMass{<:AbstractArray{T, 3}}, m_T1::DiscreteNonParametric, meta::Any) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j] := eloga[a, i, j] * probvec(q_out)[a]
     out .= exp.(out)
@@ -25,7 +25,7 @@ end
     return Categorical(normalize!(msg, 1))
 end
 
-@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass, m_in::DiscreteNonParametric, q_a::PointMass, meta::Any) = begin
+@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 3}}, meta::Any) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j] := eloga[a, i, j] * probvec(q_out)[a]
     out .= exp.(out)
@@ -34,7 +34,7 @@ end
 end
 
 # --------------- Rules for 3 interfaces (q_out PointMass, q_a DirichletCollection) ---------------
-@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass, q_a::DirichletCollection, m_T1::DiscreteNonParametric, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass{<:AbstractVector}, q_a::DirichletCollection, m_T1::DiscreteNonParametric, meta::Any) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j] := eloga[a, i, j] * probvec(q_out)[a]
     out .= exp.(out)
@@ -42,7 +42,7 @@ end
     return Categorical(normalize!(msg, 1))
 end
 
-@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass, m_in::DiscreteNonParametric, q_a::DirichletCollection, meta::Any) = begin
+@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::DirichletCollection, meta::Any) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j] := eloga[a, i, j] * probvec(q_out)[a]
     out .= exp.(out)
@@ -51,7 +51,9 @@ end
 end
 
 # --------------- Rules for 4 interfaces (q_out PointMass, q_a PointMass) ---------------
-@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass, q_a::PointMass, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any) = begin
+@rule DiscreteTransition(:in, Marginalisation) (
+    q_out::PointMass{<:AbstractVector}, q_a::PointMass{<:AbstractArray{T, 4}}, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
     out .= exp.(out)
@@ -59,7 +61,9 @@ end
     return Categorical(normalize!(msg, 1))
 end
 
-@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass, m_in::DiscreteNonParametric, q_a::PointMass, m_T2::DiscreteNonParametric, meta::Any) = begin
+@rule DiscreteTransition(:T1, Marginalisation) (
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 4}}, m_T2::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
     out .= exp.(out)
@@ -67,7 +71,9 @@ end
     return Categorical(normalize!(msg, 1))
 end
 
-@rule DiscreteTransition(:T2, Marginalisation) (q_out::PointMass, m_in::DiscreteNonParametric, q_a::PointMass, m_T1::DiscreteNonParametric, meta::Any) = begin
+@rule DiscreteTransition(:T2, Marginalisation) (
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 4}}, m_T1::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
     out .= exp.(out)
@@ -76,34 +82,37 @@ end
 end
 
 # --------------- Rules for 4 interfaces (q_out PointMass, q_a DirichletCollection) ---------------
-@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any) = begin
-    eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
-    @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
-    out .= exp.(out)
-    @tullio msg[i] := out[i, j, k] * probvec(m_T1)[j] * probvec(m_T2)[k]
-    return Categorical(normalize!(msg, 1))
-end
+@rule DiscreteTransition(:in, Marginalisation) (q_out::PointMass{<:AbstractVector}, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any) =
+    begin
+        eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
+        @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
+        out .= exp.(out)
+        @tullio msg[i] := out[i, j, k] * probvec(m_T1)[j] * probvec(m_T2)[k]
+        return Categorical(normalize!(msg, 1))
+    end
 
-@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T2::DiscreteNonParametric, meta::Any) = begin
-    eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
-    @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
-    out .= exp.(out)
-    @tullio msg[j] := out[i, j, k] * probvec(m_in)[i] * probvec(m_T2)[k]
-    return Categorical(normalize!(msg, 1))
-end
+@rule DiscreteTransition(:T1, Marginalisation) (q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T2::DiscreteNonParametric, meta::Any) =
+    begin
+        eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
+        @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
+        out .= exp.(out)
+        @tullio msg[j] := out[i, j, k] * probvec(m_in)[i] * probvec(m_T2)[k]
+        return Categorical(normalize!(msg, 1))
+    end
 
-@rule DiscreteTransition(:T2, Marginalisation) (q_out::PointMass, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T1::DiscreteNonParametric, meta::Any) = begin
-    eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
-    @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
-    out .= exp.(out)
-    @tullio msg[k] := out[i, j, k] * probvec(m_in)[i] * probvec(m_T1)[j]
-    return Categorical(normalize!(msg, 1))
-end
+@rule DiscreteTransition(:T2, Marginalisation) (q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T1::DiscreteNonParametric, meta::Any) =
+    begin
+        eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
+        @tullio out[i, j, k] := eloga[a, i, j, k] * probvec(q_out)[a]
+        out .= exp.(out)
+        @tullio msg[k] := out[i, j, k] * probvec(m_in)[i] * probvec(m_T1)[j]
+        return Categorical(normalize!(msg, 1))
+    end
 
 # --------------- Rules for 5 interfaces (q_out PointMass, q_a PointMass) ---------------
 @rule DiscreteTransition(:in, Marginalisation) (
-    q_out::PointMass, q_a::PointMass, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
-) = begin
+    q_out::PointMass{<:AbstractVector}, q_a::PointMass{<:AbstractArray{T, 5}}, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
     out .= exp.(out)
@@ -112,8 +121,8 @@ end
 end
 
 @rule DiscreteTransition(:T1, Marginalisation) (
-    q_out::PointMass, m_in::DiscreteNonParametric, q_a::PointMass, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
-) = begin
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
     out .= exp.(out)
@@ -122,8 +131,8 @@ end
 end
 
 @rule DiscreteTransition(:T2, Marginalisation) (
-    q_out::PointMass, m_in::DiscreteNonParametric, q_a::PointMass, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
-) = begin
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
     out .= exp.(out)
@@ -132,8 +141,8 @@ end
 end
 
 @rule DiscreteTransition(:T3, Marginalisation) (
-    q_out::PointMass, m_in::DiscreteNonParametric, q_a::PointMass, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
-) = begin
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::PointMass{<:AbstractArray{T, 5}}, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
+) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
     out .= exp.(out)
@@ -143,7 +152,7 @@ end
 
 # --------------- Rules for 5 interfaces (q_out PointMass, q_a DirichletCollection) ---------------
 @rule DiscreteTransition(:in, Marginalisation) (
-    q_out::PointMass, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
+    q_out::PointMass{<:AbstractVector}, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
 ) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
@@ -153,7 +162,7 @@ end
 end
 
 @rule DiscreteTransition(:T1, Marginalisation) (
-    q_out::PointMass, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T2::DiscreteNonParametric, m_T3::DiscreteNonParametric, meta::Any
 ) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
@@ -163,7 +172,7 @@ end
 end
 
 @rule DiscreteTransition(:T2, Marginalisation) (
-    q_out::PointMass, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
 ) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]
@@ -173,7 +182,7 @@ end
 end
 
 @rule DiscreteTransition(:T3, Marginalisation) (
-    q_out::PointMass, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
+    q_out::PointMass{<:AbstractVector}, m_in::DiscreteNonParametric, q_a::DirichletCollection, m_T1::DiscreteNonParametric, m_T2::DiscreteNonParametric, meta::Any
 ) = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     @tullio out[i, j, k, l] := eloga[a, i, j, k, l] * probvec(q_out)[a]


### PR DESCRIPTION
This pull request includes changes to the `DiscreteTransition` rules in several files, focusing on refining type constraints for `PointMass` and other related types. The most important changes include adding type constraints to improve type safety. This is useful if users implement `DiscreteTransition` with types that aren't necessarily `AbstractArrays` (like Tensor Decompositions) and which we can't naively multiply. This PR makes sure that the regular "rule not found error" will pop up rather than a multiplication error in the internals of the DiscreteTransition rules