### PR TITLE
Tighten dispatch for summation rules

### DIFF
--- a/src/rules/addition/in1.jl
+++ b/src/rules/addition/in1.jl
@@ -56,11 +56,10 @@ end
 
 # specialized
 @rule typeof(+)(:in1, Marginalisation) (
-    m_out::MvNormalWeightedMeanPrecision{T1}, m_in2::MvNormalWeightedMeanPrecision{T2}
-) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat} = begin
+    m_out::MvNormalWeightedMeanPrecision{T, Vector{T}, Matrix{T}}, m_in2::MvNormalWeightedMeanPrecision{T, Vector{T}, Matrix{T}}
+) where {T <: LinearAlgebra.BlasFloat} = begin
     min2, vin2 = mean_cov(m_in2)
     vout = cov(m_out)
-    T = promote_type(T1, T2)
     BLAS.gemv!('N', -one(T), vout, weightedmean(m_out), one(T), min2)
     vin2 .+= vout
     return MvNormalMeanCovariance(min2, vin2)

--- a/src/rules/addition/out.jl
+++ b/src/rules/addition/out.jl
@@ -56,11 +56,11 @@ end
 
 # specialized
 @rule typeof(+)(:out, Marginalisation) (
-    m_in1::MvNormalWeightedMeanPrecision{T1}, m_in2::MvNormalWeightedMeanPrecision{T2}
-) where {T1 <: LinearAlgebra.BlasFloat, T2 <: LinearAlgebra.BlasFloat} = begin
+    m_in1::MvNormalWeightedMeanPrecision{T, Vector{T}, Matrix{T}}, m_in2::MvNormalWeightedMeanPrecision{T, Vector{T}, Matrix{T}}
+) where {T <: LinearAlgebra.BlasFloat} = begin
+    # `mean_cov` here allocates a new matrix and vector, which can be used later on as scratch space. This is not desirable logic but it is efficient.
     min2, vin2 = mean_cov(m_in2)
     vin1 = cov(m_in1)
-    T = promote_type(T1, T2)
     BLAS.gemv!('N', one(T), vin1, weightedmean(m_in1), one(T), min2)
     vin2 .+= vin1
     return MvNormalMeanCovariance(min2, vin2)

--- a/test/rules/addition/out_tests.jl
+++ b/test/rules/addition/out_tests.jl
@@ -1,6 +1,7 @@
 
 @testitem "rules:typeof(+):out" begin
     using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
+    using StaticArrays
 
     import ReactiveMP: @test_rules
 
@@ -137,6 +138,21 @@
             (
                 input = (m_in1 = MvNormalWeightedMeanPrecision([1.0, 4.0], [2.0 1.0; 1.0 3.0]), m_in2 = MvNormalMeanCovariance([1.0, -1.0], [3.0 1.0; 1.0 4.0])),
                 output = MvNormalMeanCovariance([4 / 5, 2 / 5], [36/10 4/5; 4/5 44/10])
+            ),
+            (
+                input = (m_in1 = MvNormalWeightedMeanPrecision([1.0, 4.0], [1.0 0.0; 0.0 1.0]), m_in2 = MvNormalWeightedMeanPrecision([1.0, 1.0], [1.0 0.0; 0.0 1.0])),
+                output = MvNormalMeanCovariance([2.0, 5.0], [2.0 0.0; 0.0 2.0])
+            ),
+            (
+                input = (m_in1 = MvNormalWeightedMeanPrecision([1.0, 4.0], [1.0 0.0; 0.0 1.0]), m_in2 = MvNormalWeightedMeanPrecision([1.0, -1.0], [2.0 0.0; 0.0 2.0])),
+                output = MvNormalMeanCovariance([1.5, 3.5], [1.5 0.0; 0.0 1.5])
+            ),
+            (
+                input = (
+                    m_in1 = MvNormalWeightedMeanPrecision(SVector(1.0, 4.0), SMatrix{2, 2}(1.0, 0.0, 0.0, 1.0)),
+                    m_in2 = MvNormalWeightedMeanPrecision(SVector(1.0, -1.0), SMatrix{2, 2}(2.0, 0.0, 0.0, 2.0))
+                ),
+                output = MvNormalMeanCovariance(SVector(1.5, 3.5), SMatrix{2, 2}(1.5, 0.0, 0.0, 1.5))
             )
         ]
     end


### PR DESCRIPTION
`StaticArrays` broke in this place, and additionally you cannot call `gemv!` with mixed float type (for example `Float32` and `Float64`). New tests test this behaviour at least for `out` interface