### PR TITLE
Fix structured VMP deadlock with 3+ mutually-dependent clusters  (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Structured VMP with 3+ mutually-dependent clusters no longer deadlocks when a provisional (`is_initial`) sibling value permanently retired `PushNew()`'s mutual-refresh requirement once it settled on its real value ([#344](https://github.com/ReactiveBayes/RxInfer.jl/issues/344), [#620](https://github.com/ReactiveBayes/ReactiveMP.jl/pull/620))
+- Structured VMP with 3+ mutually-dependent clusters no longer deadlocks when an initialized message caused the first outbound message computation to consume only provisional (`is_initial`) marginals: the marginal dependencies of a node now stay consumable while all of their recent values are `is_initial`, instead of `PushNew()` requiring every dependency to refresh before the next computation. The relaxation applies to marginal dependencies only — message dependencies keep strict `PushNew()` semantics, so message-update schedules (and hence free-energy trajectories) of unaffected models remain unchanged ([#344](https://github.com/ReactiveBayes/RxInfer.jl/issues/344), [#620](https://github.com/ReactiveBayes/ReactiveMP.jl/pull/620))
 
 ## [6.3.2] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Structured VMP with 3+ mutually-dependent clusters no longer deadlocks when a provisional (`is_initial`) sibling value permanently retired `PushNew()`'s mutual-refresh requirement once it settled on its real value ([#344](https://github.com/ReactiveBayes/RxInfer.jl/issues/344), [#620](https://github.com/ReactiveBayes/ReactiveMP.jl/pull/620))
+
 ## [6.3.1] - 2026-07-06
 
 ### Fixed

--- a/src/nodes/dependencies.jl
+++ b/src/nodes/dependencies.jl
@@ -16,10 +16,21 @@ function __collect_latest_updates(f::F, collection::Tuple) where {F}
     return if isempty(collection)
         (nothing, of(nothing))
     else
+        streams = map(f, collection)
         (
             Val{map(name, collection)}(),
-            combineLatestUpdates(map(f, collection), PushNew()),
+            combineLatestUpdates(streams, PushNew(), typeof(streams), identity, __reset_vstatus_of_sources),
         )
+    end
+end
+
+# Mirrors `reset_vstatus` from `clusters.jl`/`random.jl`: without this, a sibling that only ever
+# emitted a provisional (`is_initial`) value permanently retires `PushNew()`'s mutual-refresh
+# requirement for the rest of the group once it settles on its real value.
+function __reset_vstatus_of_sources(wrapper, sources)
+    values = map(getrecent, sources)
+    if is_initial(values)
+        Rocket.fill_vstatus!(wrapper, true)
     end
 end
 

--- a/src/nodes/dependencies.jl
+++ b/src/nodes/dependencies.jl
@@ -4,22 +4,30 @@ export DefaultFunctionalDependencies,
     RequireEverythingFunctionalDependencies
 
 collect_latest_messages(dependencies, factornode, collection) =
-    __collect_latest_updates(get_stream_of_inbound_messages, collection)
+    __collect_latest_updates(
+        get_stream_of_inbound_messages, nothing, collection
+    )
 collect_latest_marginals(dependencies, factornode, collection) =
-    __collect_latest_updates(get_stream_of_marginals, collection)
+    __collect_latest_updates(
+        get_stream_of_marginals, __reset_vstatus_of_sources, collection
+    )
 
-function __collect_latest_updates(f::F, collection) where {F}
-    return __collect_latest_updates(f, Tuple(collection))
+function __collect_latest_updates(f::F, callback::C, collection) where {F, C}
+    return __collect_latest_updates(f, callback, Tuple(collection))
 end
 
-function __collect_latest_updates(f::F, collection::Tuple) where {F}
+function __collect_latest_updates(
+    f::F, callback::C, collection::Tuple
+) where {F, C}
     return if isempty(collection)
         (nothing, of(nothing))
     else
         streams = map(f, collection)
         (
             Val{map(name, collection)}(),
-            combineLatestUpdates(streams, PushNew(), typeof(streams), identity, __reset_vstatus_of_sources),
+            combineLatestUpdates(
+                streams, PushNew(), typeof(streams), identity, callback
+            ),
         )
     end
 end
@@ -27,6 +35,11 @@ end
 # Mirrors `reset_vstatus` from `clusters.jl`/`random.jl`: without this, a sibling that only ever
 # emitted a provisional (`is_initial`) value permanently retires `PushNew()`'s mutual-refresh
 # requirement for the rest of the group once it settles on its real value.
+# The reset is applied to marginal dependencies only. Applying it to message dependencies as well
+# alters the message-update schedule in models that are not affected by the deadlock (an outbound
+# message would be recomputed as soon as a single dependency refreshes while the others are still
+# `is_initial`), which changes free-energy trajectories and breaks strict FE-monotonicity
+# guarantees downstream. Marginal dependencies alone are sufficient to resolve the deadlock.
 function __reset_vstatus_of_sources(wrapper, sources)
     values = map(getrecent, sources)
     if is_initial(values)

--- a/test/nodes/dependencies_tests.jl
+++ b/test/nodes/dependencies_tests.jl
@@ -138,6 +138,156 @@ end
     end
 end
 
+@testitem "collect_latest_marginals should re-fire while all dependencies are initial (deadlock guard, RxInfer#344)" begin
+    # Regression test for https://github.com/ReactiveBayes/RxInfer.jl/issues/344
+    # With plain `PushNew()` semantics every marginal dependency must refresh before the
+    # combined stream may fire again. If the first firing consumed only provisional
+    # (`is_initial`) marginals, structured VMP with 3+ mutually-dependent clusters deadlocks:
+    # the combination never fires again because the clusters wait on each other.
+    # `__reset_vstatus_of_sources` must keep the combination hot while all of its recent
+    # values are `is_initial`, and strict `PushNew()` semantics must be restored as soon as
+    # at least one dependency holds a real (non-initial) value.
+    include("../testutilities.jl")
+    using BayesBase, Rocket
+
+    import ReactiveMP:
+        collect_latest_marginals,
+        default_functional_dependencies,
+        getlocalclusters,
+        set_stream_of_marginals!,
+        get_node_local_marginals
+
+    struct ArbitraryNodeForMarginalsVstatusReset end
+
+    @node ArbitraryNodeForMarginalsVstatusReset Stochastic [a, b, c]
+
+    node = factornode(
+        ArbitraryNodeForMarginalsVstatusReset,
+        [(:a, randomvar()), (:b, randomvar()), (:c, randomvar())],
+        ((1,), (2,), (3,)),
+    )
+    dependencies = default_functional_dependencies(
+        ArbitraryNodeForMarginalsVstatusReset
+    )
+
+    a, b, c = get_node_local_marginals(getlocalclusters(node))
+
+    sa = RecentSubject(Marginal)
+    sb = RecentSubject(Marginal)
+    sc = RecentSubject(Marginal)
+
+    set_stream_of_marginals!(a, sa)
+    set_stream_of_marginals!(b, sb)
+    set_stream_of_marginals!(c, sc)
+
+    (tag, stream) = collect_latest_marginals(dependencies, node, (a, b, c))
+
+    updates = Ref(0)
+    subscription = subscribe!(stream, (_) -> updates[] += 1)
+
+    initial(value)     = Marginal(value, false, true)
+    non_initial(value) = Marginal(value, false, false)
+
+    # The combination fires for the first time only once all dependencies emitted
+    next!(sa, initial(PointMass(1)))
+    next!(sb, initial(PointMass(2)))
+    @test updates[] == 0
+    next!(sc, initial(PointMass(3)))
+    @test updates[] == 1
+
+    # All consumed values were `is_initial`, thus a single refreshed dependency must be
+    # enough to re-fire the combination (this is the #344 deadlock fix)
+    next!(sa, non_initial(PointMass(1)))
+    @test updates[] == 2
+
+    # The last firing consumed a real value for `a`, thus strict `PushNew()` semantics
+    # apply again: the combination must not re-fire until all dependencies refresh
+    next!(sb, non_initial(PointMass(2)))
+    @test updates[] == 2
+    next!(sc, non_initial(PointMass(3)))
+    @test updates[] == 2
+    next!(sa, non_initial(PointMass(1)))
+    @test updates[] == 3
+
+    # And a single refresh alone keeps being insufficient
+    next!(sb, non_initial(PointMass(2)))
+    @test updates[] == 3
+
+    unsubscribe!(subscription)
+end
+
+@testitem "collect_latest_messages should keep strict PushNew semantics even for initial messages" begin
+    # Guards the scoping of the RxInfer#344 deadlock fix: the `is_initial` vstatus reset is
+    # deliberately applied to marginal dependencies only. Applying it to message dependencies
+    # as well changes the message-update schedule in models unaffected by the deadlock
+    # (an outbound message would be recomputed as soon as a single dependency refreshes while
+    # the others are still `is_initial`), which changes free-energy trajectories and breaks
+    # strict FE-monotonicity guarantees downstream (observed in RxInfer model tests).
+    include("../testutilities.jl")
+    using BayesBase, Rocket
+
+    import ReactiveMP:
+        MessageObservable,
+        collect_latest_messages,
+        default_functional_dependencies,
+        getinterfaces,
+        getvariable,
+        connect!
+
+    struct ArbitraryNodeForMessagesVstatusReset end
+
+    @node ArbitraryNodeForMessagesVstatusReset Stochastic [a, b, c]
+
+    node = factornode(
+        ArbitraryNodeForMessagesVstatusReset,
+        [(:a, randomvar()), (:b, randomvar()), (:c, randomvar())],
+        ((1, 2, 3),),
+    )
+    dependencies = default_functional_dependencies(
+        ArbitraryNodeForMessagesVstatusReset
+    )
+
+    a, b, c = getinterfaces(node)
+
+    sa = RecentSubject(Message)
+    sb = RecentSubject(Message)
+    sc = RecentSubject(Message)
+
+    # Wire the variables' outbound message streams (the inbound message streams of the
+    # interfaces) manually, the same way `activate!` would do
+    for (interface, subject) in zip((a, b, c), (sa, sb, sc))
+        output = MessageObservable(Message)
+        connect!(output, subject)
+        push!(getvariable(interface).output_messages, output)
+    end
+
+    (tag, stream) = collect_latest_messages(dependencies, node, (a, b, c))
+
+    updates = Ref(0)
+    subscription = subscribe!(stream, (_) -> updates[] += 1)
+
+    initial(value)     = Message(value, false, true)
+    non_initial(value) = Message(value, false, false)
+
+    # The combination fires for the first time only once all dependencies emitted
+    next!(sa, initial(PointMass(1)))
+    next!(sb, initial(PointMass(2)))
+    @test updates[] == 0
+    next!(sc, initial(PointMass(3)))
+    @test updates[] == 1
+
+    # Even though all consumed values were `is_initial`, message dependencies must keep
+    # strict `PushNew()` semantics: a single refreshed dependency is not enough to re-fire
+    next!(sa, non_initial(PointMass(1)))
+    @test updates[] == 1
+    next!(sb, non_initial(PointMass(2)))
+    @test updates[] == 1
+    next!(sc, non_initial(PointMass(3)))
+    @test updates[] == 2
+
+    unsubscribe!(subscription)
+end
+
 @testitem "Various functional dependencies" begin
     include("../testutilities.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ end
 if isempty(ARGS)
     @run_package_tests(verbose = true)
 else
-    filtered_files = map(arg -> join(split(arg, ":"), "/"))
+    filtered_files = map(arg -> join(split(arg, ":"), "/"), ARGS)
     filter_fn = ti -> any(occursin(ti.filename), filtered_files)
     @run_package_tests(filter = filter_fn, verbose = true)
 end


### PR DESCRIPTION
Fixes ReactiveBayes/RxInfer.jl#344.

```__collect_latest_updates``` combines sibling cluster dependencies via ```combineLatestUpdates``` with ```PushNew()``` which requires every sibling to emit a new value before firing again. If a sibling only ever emits a provisional ```(is_initial)``` value before settling on its real one, the mutual refresh requirement is never satisfied again once that stream settles, permanently deadlocking 3+ mutually dependent structured VMP clusters.

Fix mirrors the existing reset_vstatus pattern from clusters.jl/random.jl: when the combined sources are still provisional, force the wrapper's vstatus to refresh.

Verified: fixes the reported repro, converges to the same posterior as the unbroken case, no hang under a full-seed stress case, full existing test suite passes.