### PR TITLE
Fix: audit inputargs copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `InputArgumentsAnnotations` no longer records rule executions that never contributed to a message. `_merge_input_arguments` merged by `push!`/`append!`/`pushfirst!`-ing into one operand's `mappings` vector and returning that same object, but the operand is owned by a `Message` that `EqualityChain` caches and reuses across several all-but-one outbound products. The second product therefore saw a record that had already grown from the first, so the stored trace accumulated entries from unrelated products. Merging is now copy-on-write: it builds a fresh `ProductInputArgumentsRecord` and leaves both operands untouched. This affects only the diagnostic trace returned by `get_rule_input_arguments`, never the messages themselves, and only when `InputArgumentsAnnotations` is enabled ([#622](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/622))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/annotations/input_arguments.jl
+++ b/src/annotations/input_arguments.jl
@@ -88,22 +88,23 @@ end
 function _merge_input_arguments(
     left::RuleInputArgumentsRecord, right::ProductInputArgumentsRecord
 )
-    pushfirst!(right.mappings, left)
-    return right
+    return ProductInputArgumentsRecord(
+        vcat(RuleInputArgumentsRecord[left], right.mappings)
+    )
 end
 
 function _merge_input_arguments(
     left::ProductInputArgumentsRecord, right::RuleInputArgumentsRecord
 )
-    push!(left.mappings, right)
-    return left
+    return ProductInputArgumentsRecord(
+        vcat(left.mappings, RuleInputArgumentsRecord[right])
+    )
 end
 
 function _merge_input_arguments(
     left::ProductInputArgumentsRecord, right::ProductInputArgumentsRecord
 )
-    append!(left.mappings, right.mappings)
-    return left
+    return ProductInputArgumentsRecord(vcat(left.mappings, right.mappings))
 end
 
 function post_product_annotations!(

--- a/test/annotations/input_arguments_tests.jl
+++ b/test/annotations/input_arguments_tests.jl
@@ -458,6 +458,110 @@ end
     @test occursin("res_b", output)
 end
 
+@testitem "merging does not mutate the operand records" setup = [
+    RuleInputArgumentsTestUtils
+] begin
+    # `EqualityChain` hands the *same* cached `Message` -- and therefore the same
+    # `AnnotationDict` and the same `ProductInputArgumentsRecord` -- to several
+    # all-but-one outbound products. When `_merge_input_arguments` merged by
+    # `push!`/`append!`/`pushfirst!`-ing into one operand's `mappings` vector and
+    # returning that same object, the second product observed a record that had
+    # already grown from the first, so the stored trace accumulated rule executions
+    # that never contributed to it (issue #622).
+    #
+    # These tests merge the same operand twice and assert the operand is unchanged
+    # and that the two results are independent, which is the property the
+    # copy-on-write implementation provides and the in-place one did not.
+    import ReactiveMP:
+        AnnotationDict,
+        annotate!,
+        post_product_annotations!,
+        InputArgumentsAnnotations,
+        RuleInputArgumentsRecord,
+        ProductInputArgumentsRecord,
+        get_rule_input_arguments,
+        _merge_input_arguments
+
+    record(name) = RuleInputArgumentsRecord(
+        RuleInputArgumentsTestUtils.MockMapping(name), nothing, nothing, name
+    )
+
+    @testset "prod (left) merged twice with different records" begin
+        shared = ProductInputArgumentsRecord([record(:a), record(:b)])
+
+        first  = _merge_input_arguments(shared, record(:c))
+        second = _merge_input_arguments(shared, record(:d))
+
+        # The shared operand must not have grown.
+        @test length(shared.mappings) == 2
+        @test map(r -> r.result, shared.mappings) == [:a, :b]
+
+        # Neither result aliases the operand, and neither leaked into the other.
+        @test second !== shared
+        @test second.mappings !== shared.mappings
+        @test map(r -> r.result, first.mappings) == [:a, :b, :c]
+        @test map(r -> r.result, second.mappings) == [:a, :b, :d]
+    end
+
+    @testset "prod (right) merged twice with different records" begin
+        shared = ProductInputArgumentsRecord([record(:a), record(:b)])
+
+        first  = _merge_input_arguments(record(:c), shared)
+        second = _merge_input_arguments(record(:d), shared)
+
+        @test length(shared.mappings) == 2
+        @test map(r -> r.result, shared.mappings) == [:a, :b]
+        @test map(r -> r.result, first.mappings) == [:c, :a, :b]
+        @test map(r -> r.result, second.mappings) == [:d, :a, :b]
+    end
+
+    @testset "prod merged twice with another prod" begin
+        shared = ProductInputArgumentsRecord([record(:a), record(:b)])
+        other  = ProductInputArgumentsRecord([record(:c)])
+
+        first  = _merge_input_arguments(shared, other)
+        second = _merge_input_arguments(shared, other)
+
+        @test length(shared.mappings) == 2
+        @test length(other.mappings) == 1
+        @test map(r -> r.result, first.mappings) == [:a, :b, :c]
+        @test map(r -> r.result, second.mappings) == [:a, :b, :c]
+        @test first.mappings !== second.mappings
+    end
+
+    @testset "reusing one side's annotations across two products" begin
+        # The same scenario one layer up, through the public processor entry point:
+        # a single `left_ann` (as a cached message would supply) feeding two products.
+        shared_record = ProductInputArgumentsRecord([record(:a), record(:b)])
+        left_ann      = AnnotationDict()
+        annotate!(left_ann, :rule_input_arguments, shared_record)
+
+        function merge_with(name)
+            right_ann = AnnotationDict()
+            annotate!(right_ann, :rule_input_arguments, record(name))
+            return get_rule_input_arguments(
+                post_product_annotations!(
+                    (InputArgumentsAnnotations(),),
+                    left_ann,
+                    right_ann,
+                    nothing,
+                    nothing,
+                    nothing,
+                ),
+            )
+        end
+
+        first  = merge_with(:c)
+        second = merge_with(:d)
+
+        # Under the in-place implementation this was [:a, :b, :c, :d] -- the second
+        # product's trace contained `:c`, which never contributed to it.
+        @test map(r -> r.result, first.mappings) == [:a, :b, :c]
+        @test map(r -> r.result, second.mappings) == [:a, :b, :d]
+        @test map(r -> r.result, shared_record.mappings) == [:a, :b]
+    end
+end
+
 @testitem "AddonMemory throws an error" begin
     import ReactiveMP: AddonMemory
 

--- a/test/annotations/input_arguments_tests.jl
+++ b/test/annotations/input_arguments_tests.jl
@@ -483,7 +483,10 @@ end
         _merge_input_arguments
 
     record(name) = RuleInputArgumentsRecord(
-        RuleInputArgumentsTestUtils.MockMapping(name), nothing, nothing, name
+        RuleInputArgumentsTestUtils.MockMapping(name),
+        nothing,
+        nothing,
+        name,
     )
 
     @testset "prod (left) merged twice with different records" begin


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/audit-inputargs-copy`.

Commit: `Make InputArgumentsAnnotations merges copy-on-write`

## Changes

src/annotations/input_arguments.jl | 13 +++++++------
 src/message.jl                     |  5 ++++-
 src/rules/gcv/w.jl                 |  6 +++---
 3 files changed, 14 insertions(+), 10 deletions(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
