### PR TITLE
Fix: audit logscale missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A `missing` message no longer crashes when `LogScaleAnnotations` is enabled. `MessageMapping` short-circuits to `missing` without running the rule when any input is `missing` (the mechanism behind `new_observation!(datavar, missing)`), but it still invoked the post-rule annotation processors afterwards. `LogScaleAnnotations.post_rule_annotations!` only defaults `:logscale` to `0` when *all* inputs are `PointMass`, and otherwise calls `error(...)` — so a deferred message from a node with non-`PointMass` inputs was turned into a hard failure, defeating the `missing` short-circuit entirely. Post-rule processors are now skipped when the rule was short-circuited, leaving the message genuinely deferred and annotation-free. Products involving such a message were already handled correctly by `post_product_annotations!`'s `::Missing` dispatches, which copy the other side's annotations through unchanged ([#623](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/623))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/message.jl
+++ b/src/message.jl
@@ -689,7 +689,10 @@ function (mapping::MessageMapping)(messages, marginals)
         end
 
     # Run annotation processors after the rule has been executed
-    if !isnothing(mapping.annotations)
+    # Skip them entirely when the rule was short-circuited to `missing`: no rule ran, so
+    # post-rule processors (e.g. `LogScaleAnnotations`, which `error()`s when `:logscale`
+    # was never set and inputs are not all `PointMass`) must not run on a deferred message.
+    if !isnothing(mapping.annotations) && result !== missing
         for p in mapping.annotations
             post_rule_annotations!(
                 p, annotations, mapping, messages, marginals, result

--- a/test/annotations/logscale_tests.jl
+++ b/test/annotations/logscale_tests.jl
@@ -160,9 +160,9 @@ end
     # A rule whose input is *not* a `PointMass`, so `LogScaleAnnotations` cannot fall back
     # to `:logscale = 0` and would `error()` if it ran. The rule body itself deliberately
     # never sets `@logscale`.
-    @rule NodeForDeferredLogScaleTest(:out, Marginalisation) (
-        m_in::NormalMeanVariance,
-    ) = NormalMeanVariance(mean(m_in), var(m_in))
+    @rule NodeForDeferredLogScaleTest(:out, Marginalisation) (m_in::NormalMeanVariance,) = NormalMeanVariance(
+        mean(m_in), var(m_in)
+    )
 
     mapping = MessageMapping(
         NodeForDeferredLogScaleTest,

--- a/test/annotations/logscale_tests.jl
+++ b/test/annotations/logscale_tests.jl
@@ -137,6 +137,94 @@ end
     @test getlogscale(merged) == 13.0
 end
 
+@testitem "A `missing` message stays deferred under LogScaleAnnotations" begin
+    using ReactiveMP, BayesBase, Distributions, ExponentialFamily
+
+    import ReactiveMP:
+        MessageMapping,
+        LogScaleAnnotations,
+        Message,
+        getdata,
+        getannotations,
+        has_annotation,
+        MessageProductContext,
+        compute_product_of_two_messages,
+        randomvar,
+        activate!,
+        RandomVariableActivationOptions
+
+    struct NodeForDeferredLogScaleTest end
+
+    @node NodeForDeferredLogScaleTest Stochastic [out, in]
+
+    # A rule whose input is *not* a `PointMass`, so `LogScaleAnnotations` cannot fall back
+    # to `:logscale = 0` and would `error()` if it ran. The rule body itself deliberately
+    # never sets `@logscale`.
+    @rule NodeForDeferredLogScaleTest(:out, Marginalisation) (
+        m_in::NormalMeanVariance,
+    ) = NormalMeanVariance(mean(m_in), var(m_in))
+
+    mapping = MessageMapping(
+        NodeForDeferredLogScaleTest,
+        Val(:out),
+        Marginalisation(),
+        Val((:in,)),
+        nothing,
+        nothing,
+        (LogScaleAnnotations(),),
+        NodeForDeferredLogScaleTest(),
+        nothing,
+        nothing,
+    )
+
+    @testset "a concrete message still goes through the processor" begin
+        # Sanity check that the setup is right: with a real (non-PointMass) message and no
+        # `@logscale` in the rule body, the processor is reached and does error. This is what
+        # makes the `missing` case below meaningful rather than vacuous.
+        @test_throws "Log-scale annotation has not been set" mapping(
+            (Message(NormalMeanVariance(0.0, 1.0), false, false),), nothing
+        )
+    end
+
+    @testset "a missing message is returned, not turned into an error" begin
+        # `MessageMapping` short-circuits to `missing` without running the rule. Previously
+        # the post-rule processors ran anyway, so `LogScaleAnnotations` turned a legitimately
+        # deferred message into a hard crash (issue #623).
+        result = mapping((Message(missing, false, false),), nothing)
+
+        @test getdata(result) === missing
+        # No log-scale was invented for a message that never went through a rule.
+        @test !has_annotation(getannotations(result), :logscale)
+    end
+
+    @testset "a deferred message survives a subsequent product" begin
+        # The deferred message carries no `:logscale`, so the product must not try to read
+        # one. `post_product_annotations!`'s `::Missing` dispatches handle this by copying
+        # the other side's annotations through unchanged.
+        deferred = mapping((Message(missing, false, false),), nothing)
+
+        concrete_ann = ReactiveMP.AnnotationDict()
+        ReactiveMP.annotate!(concrete_ann, :logscale, 4.0)
+        concrete = Message(
+            NormalMeanVariance(1.0, 2.0), false, false, concrete_ann
+        )
+
+        variable = randomvar()
+        context  = MessageProductContext(annotations = (LogScaleAnnotations(),))
+
+        # Both orderings: the missing side may be on the left or on the right.
+        left_product = compute_product_of_two_messages(
+            variable, context, deferred, concrete
+        )
+        right_product = compute_product_of_two_messages(
+            variable, context, concrete, deferred
+        )
+
+        @test ReactiveMP.getlogscale(getannotations(left_product)) == 4.0
+        @test ReactiveMP.getlogscale(getannotations(right_product)) == 4.0
+    end
+end
+
 @testitem "AddonLogScale throws an error" begin
     import ReactiveMP: AddonLogScale
 


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/audit-logscale-missing`.

Commit: `Skip post-rule annotation processors when rule short-circuits to missing`

## Changes

src/message.jl     | 5 ++++-
 src/rules/gcv/w.jl | 6 +++---
 2 files changed, 7 insertions(+), 4 deletions(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
