### PR TITLE
Add `rtol` option to `@test_rules` / `@test_marginalrules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `rtol` option for `@test_rules` / `@test_marginalrules`, accepted in the same spellings as `atol` (a single number or an array of `Type => value` pairs) and forwarded to `isapprox` alongside `atol`. This makes it possible to test rules whose inputs are very large or very small, where a fixed absolute tolerance is either meaninglessly loose or impossible to satisfy. The default is `0` for every float type, which reproduces `Base.isapprox`'s own behaviour when a positive `atol` is supplied, so existing test invocations are numerically unchanged. Set `atol = 0` explicitly to test purely relatively ([#573](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/573))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -922,7 +922,8 @@ The macro takes three arguments:
 The following options are available:
 
 - `check_type_promotion`: By default, this option is set to `false`. If set to `true`, the macro generates an extensive list of extra tests that aim to check the correct type promotion within the tests. For example, if all inputs are of type `Float32`, then the expected output should also be of type `Float32`. See the `paramfloattype` and `convert_paramfloattype` functions for details.
-- `atol`: Sets the desired accuracy for the tests. The tests use the `custom_rule_isapprox` function from `ReactiveMP` to check if outputs are approximately the same. This argument can be either a single number or an array of `key => value` pairs.
+- `atol`: Sets the desired absolute accuracy for the tests. The tests use the `custom_rule_isapprox` function from `ReactiveMP` to check if outputs are approximately the same. This argument can be either a single number or an array of `key => value` pairs.
+- `rtol`: Sets the desired relative accuracy for the tests, in the same format as `atol` (either a single number or an array of `key => value` pairs). Useful when the rule's inputs (and hence outputs) are very large or very small, where a fixed absolute tolerance is either meaninglessly loose or impossible to satisfy.
 - `extra_float_types`: A set of extra float types to be used in the `check_type_promotion` tests. This argument has no effect if `check_type_promotion` is set to `false`.
 
 The default values for the `atol` option are:
@@ -930,6 +931,17 @@ The default values for the `atol` option are:
 - `Float32`: `1e-4`
 - `Float64`: `1e-6`
 - `BigFloat`: `1e-8`
+
+The default value of `rtol` is `0` for every float type, which reproduces the behaviour of `Base.isapprox`
+when only a positive `atol` is given. Both tolerances are forwarded to `isapprox`, so they combine as
+`|actual - expected| <= max(atol, rtol * max(|actual|, |expected|))` — that is, a test passes if *either*
+tolerance is satisfied. To test purely relatively, set `atol` to `0` explicitly:
+
+```julia
+@test_rules [atol = 0, rtol = 1e-8] NormalMeanVariance(:out, Marginalisation) [
+    (input = (m_μ = PointMass(1e10), m_v = PointMass(1e10)), output = NormalMeanVariance(1e10, 1e10))
+]
+```
 
 ## Examples
 
@@ -1091,10 +1103,18 @@ Base.@kwdef mutable struct TestRulesConfiguration
     float_tolerance::Dict = Dict(
         Float32 => 1e-4, Float64 => 1e-6, BigFloat => 1e-8
     )
+    float_rtolerance::Dict = Dict(
+        Float32 => 0.0, Float64 => 0.0, BigFloat => 0.0
+    )
     extra_float_types::Vector = [Float32, Float64, BigFloat]
 end
 
 const DefaultFloatTolerance = 1e-6
+
+# `0` reproduces Julia's own `isapprox` behaviour when a positive `atol` is supplied
+# (`rtoldefault` returns zero in that case), so the default leaves every existing
+# `@test_rules` invocation numerically unchanged.
+const DefaultFloatRelativeTolerance = 0.0
 
 check_type_promotion(configuration::TestRulesConfiguration)::Bool =
     configuration.check_type_promotion
@@ -1116,6 +1136,27 @@ float_tolerance!(configuration::TestRulesConfiguration, atol::Number) = foreach(
 float_tolerance!(configuration::TestRulesConfiguration, atol::AbstractArray) =
     foreach(
         ((key, value),) -> float_tolerance!(configuration, key, value), atol
+    )
+
+float_rtolerance(configuration::TestRulesConfiguration) =
+    configuration.float_rtolerance
+float_rtolerance(configuration::TestRulesConfiguration, ::Type{T}) where {T} =
+    get(
+        () -> DefaultFloatRelativeTolerance,
+        float_rtolerance(configuration),
+        T,
+    )
+
+float_rtolerance!(
+    configuration::TestRulesConfiguration, ::Type{T}, rtol::Number
+) where {T} = configuration.float_rtolerance[T] = rtol
+float_rtolerance!(configuration::TestRulesConfiguration, rtol::Number) = foreach(
+    ((key, _),) -> float_rtolerance!(configuration, key, rtol),
+    float_rtolerance(configuration),
+)
+float_rtolerance!(configuration::TestRulesConfiguration, rtol::AbstractArray) =
+    foreach(
+        ((key, value),) -> float_rtolerance!(configuration, key, value), rtol
     )
 
 extra_float_types(configuration::TestRulesConfiguration) =
@@ -1141,6 +1182,8 @@ function test_rules_parse_configuration(configuration::Symbol, options::Expr)
             ))
         elseif key === :atol
             return :(ReactiveMP.float_tolerance!($configuration, $value))
+        elseif key === :rtol
+            return :(ReactiveMP.float_rtolerance!($configuration, $value))
         elseif key === :extra_float_types
             return :(ReactiveMP.extra_float_types!($configuration, $value))
         else
@@ -1297,8 +1340,12 @@ function test_rules_generate_testset(
                 actual_output, expected_output
             )
             local _tolerance = ReactiveMP.float_tolerance($configuration, _T)
+            local _rtolerance = ReactiveMP.float_rtolerance($configuration, _T)
             local _isapprox = ReactiveMP.custom_rule_isapprox(
-                actual_output, expected_output; atol = _tolerance
+                actual_output,
+                expected_output;
+                atol = _tolerance,
+                rtol = _rtolerance,
             )
             local _isequal_typeof = ReactiveMP.BayesBase.isequal_typeof(
                 actual_output, expected_output

--- a/src/rule.jl
+++ b/src/rule.jl
@@ -1141,19 +1141,16 @@ float_tolerance!(configuration::TestRulesConfiguration, atol::AbstractArray) =
 float_rtolerance(configuration::TestRulesConfiguration) =
     configuration.float_rtolerance
 float_rtolerance(configuration::TestRulesConfiguration, ::Type{T}) where {T} =
-    get(
-        () -> DefaultFloatRelativeTolerance,
-        float_rtolerance(configuration),
-        T,
-    )
+    get(() -> DefaultFloatRelativeTolerance, float_rtolerance(configuration), T)
 
 float_rtolerance!(
     configuration::TestRulesConfiguration, ::Type{T}, rtol::Number
 ) where {T} = configuration.float_rtolerance[T] = rtol
-float_rtolerance!(configuration::TestRulesConfiguration, rtol::Number) = foreach(
-    ((key, _),) -> float_rtolerance!(configuration, key, rtol),
-    float_rtolerance(configuration),
-)
+float_rtolerance!(configuration::TestRulesConfiguration, rtol::Number) =
+    foreach(
+        ((key, _),) -> float_rtolerance!(configuration, key, rtol),
+        float_rtolerance(configuration),
+    )
 float_rtolerance!(configuration::TestRulesConfiguration, rtol::AbstractArray) =
     foreach(
         ((key, value),) -> float_rtolerance!(configuration, key, value), rtol

--- a/test/rule_tests.jl
+++ b/test/rule_tests.jl
@@ -63,9 +63,7 @@
             # `rtol` defaults to zero for every float type, which keeps `isapprox`
             # behaving exactly as it did before `rtol` was configurable
             let configuration = TestRulesConfiguration()
-                @test all(
-                    iszero, values(float_rtolerance(configuration))
-                )
+                @test all(iszero, values(float_rtolerance(configuration)))
                 for T in [Float32, Float64, BigFloat, Float16, Int]
                     @test iszero(float_rtolerance(configuration, T))
                 end
@@ -617,10 +615,9 @@
             # The default `atol = 1e-6` cannot possibly be satisfied here.
             let statuses = Bool[]
                 with_logger(SimpleLogger(IOBuffer())) do
-                    ReactiveMP.@test_rules (status) ->
-                        push!(statuses, status) [check_type_promotion = false] TestNodeForRtolOption(
-                        :out, Marginalisation
-                    ) [(
+                    ReactiveMP.@test_rules (status) -> push!(statuses, status) [
+                        check_type_promotion = false
+                    ] TestNodeForRtolOption(:out, Marginalisation) [(
                         input = (m_x = PointMass(1e10),),
                         output = PointMass(1e10),
                     )]
@@ -631,12 +628,10 @@
             # The same entry passes once a relative tolerance loose enough to cover
             # the 1e-4 relative error is supplied.
             let statuses = Bool[]
-                ReactiveMP.@test_rules (status) ->
-                    push!(statuses, status) [
+                ReactiveMP.@test_rules (status) -> push!(statuses, status) [
                     check_type_promotion = false, atol = 0, rtol = 1e-3
                 ] TestNodeForRtolOption(:out, Marginalisation) [(
-                    input = (m_x = PointMass(1e10),),
-                    output = PointMass(1e10),
+                    input = (m_x = PointMass(1e10),), output = PointMass(1e10)
                 )]
                 @test statuses == [true]
             end
@@ -645,8 +640,7 @@
             # relative error still fails, at any magnitude.
             let statuses = Bool[]
                 with_logger(SimpleLogger(IOBuffer())) do
-                    ReactiveMP.@test_rules (status) ->
-                        push!(statuses, status) [
+                    ReactiveMP.@test_rules (status) -> push!(statuses, status) [
                         check_type_promotion = false, atol = 0, rtol = 1e-6
                     ] TestNodeForRtolOption(:out, Marginalisation) [
                         (
@@ -665,26 +659,22 @@
             # `atol` and `rtol` combine disjunctively: a tiny-magnitude entry that
             # `rtol` rejects is still accepted when `atol` alone covers it.
             let statuses = Bool[]
-                ReactiveMP.@test_rules (status) ->
-                    push!(statuses, status) [
+                ReactiveMP.@test_rules (status) -> push!(statuses, status) [
                     check_type_promotion = false, atol = 1e-6, rtol = 1e-9
                 ] TestNodeForRtolOption(:out, Marginalisation) [(
-                    input = (m_x = PointMass(1e-10),),
-                    output = PointMass(1e-10),
+                    input = (m_x = PointMass(1e-10),), output = PointMass(1e-10)
                 )]
                 @test statuses == [true]
             end
 
             # Per-type `rtol` is honoured, mirroring the `atol` spelling.
             let statuses = Bool[]
-                ReactiveMP.@test_rules (status) ->
-                    push!(statuses, status) [
+                ReactiveMP.@test_rules (status) -> push!(statuses, status) [
                     check_type_promotion = false,
                     atol = 0,
                     rtol = [Float64 => 1e-3],
                 ] TestNodeForRtolOption(:out, Marginalisation) [(
-                    input = (m_x = PointMass(1e10),),
-                    output = PointMass(1e10),
+                    input = (m_x = PointMass(1e10),), output = PointMass(1e10)
                 )]
                 @test statuses == [true]
             end

--- a/test/rule_tests.jl
+++ b/test/rule_tests.jl
@@ -9,6 +9,7 @@
         import ReactiveMP: TestRulesConfiguration
         import ReactiveMP: check_type_promotion, check_type_promotion!
         import ReactiveMP: float_tolerance, float_tolerance!
+        import ReactiveMP: float_rtolerance, float_rtolerance!
         import ReactiveMP: extra_float_types, extra_float_types!
         import ReactiveMP: test_rules_parse_configuration
         import ReactiveMP: rule_macro_convert_to_expr
@@ -59,6 +60,61 @@
                 end
             end
 
+            # `rtol` defaults to zero for every float type, which keeps `isapprox`
+            # behaving exactly as it did before `rtol` was configurable
+            let configuration = TestRulesConfiguration()
+                @test all(
+                    iszero, values(float_rtolerance(configuration))
+                )
+                for T in [Float32, Float64, BigFloat, Float16, Int]
+                    @test iszero(float_rtolerance(configuration, T))
+                end
+            end
+
+            # check rtol can be set as a single number
+            let configuration = TestRulesConfiguration()
+                for rtol in (1e-6, 1e-12)
+                    float_rtolerance!(configuration, rtol)
+                    @test all(
+                        tolerance -> isequal(tolerance, rtol),
+                        values(float_rtolerance(configuration)),
+                    )
+                end
+            end
+
+            # check rtol can be set as an array of pairs
+            let configuration = TestRulesConfiguration()
+                for rtol in [
+                    [Float32 => 1e-5, Float64 => 1e-11],
+                    [Float32 => 1e-4, Float64 => 1e-10],
+                ]
+                    float_rtolerance!(configuration, rtol)
+                    for (key, value) in rtol
+                        @test isequal(
+                            float_rtolerance(configuration, key), value
+                        )
+                    end
+                end
+            end
+
+            # check rtol can be set individually
+            let configuration = TestRulesConfiguration()
+                for T in [Float32, Float16, BigFloat, Int],
+                    rtol in (1e-6, 1e-12)
+
+                    float_rtolerance!(configuration, T, rtol)
+                    @test isequal(float_rtolerance(configuration, T), rtol)
+                end
+            end
+
+            # `atol` and `rtol` are independent knobs
+            let configuration = TestRulesConfiguration()
+                float_tolerance!(configuration, Float64, 1e-3)
+                float_rtolerance!(configuration, Float64, 1e-9)
+                @test isequal(float_tolerance(configuration, Float64), 1e-3)
+                @test isequal(float_rtolerance(configuration, Float64), 1e-9)
+            end
+
             # extra_float_types setter test
             let configuration = TestRulesConfiguration()
                 for extra_types in ([Float64, Float32], [Int, BigFloat])
@@ -77,6 +133,7 @@
             for name in (:configuration, :blabla),
                 check in (true, false),
                 atol in (1e-4, :([Float64 => 1e-11, Float32 => 1e-4])),
+                rtol in (1e-8, :([Float64 => 1e-13, Float32 => 1e-6])),
                 extra_types in (:([Float64]), :([Float32, BigFloat]))
 
                 expression = test_rules_parse_configuration(
@@ -84,6 +141,7 @@
                     :([
                         check_type_promotion = $check,
                         atol = $atol,
+                        rtol = $rtol,
                         extra_float_types = $extra_types,
                     ]),
                 )
@@ -96,6 +154,9 @@
                 )
                 @test inexpr(
                     expression, :(ReactiveMP.float_tolerance!($name, $atol))
+                )
+                @test inexpr(
+                    expression, :(ReactiveMP.float_rtolerance!($name, $rtol))
                 )
                 @test inexpr(
                     expression,
@@ -138,6 +199,7 @@
                 @test inexpr(expression, output)
                 @test inexpr(expression, test_f)
                 @test inexpr(expression, :(ReactiveMP.float_tolerance))
+                @test inexpr(expression, :(ReactiveMP.float_rtolerance))
                 @test inexpr(expression, :(ReactiveMP.custom_rule_isapprox))
                 @test inexpr(expression, :(ReactiveMP.BayesBase.isequal_typeof))
             end
@@ -538,6 +600,94 @@
                 "Testset for rule TestNodeForTestRuleMacro(:out, Marginalisation) has failed",
                 test_output,
             )
+        end
+
+        @testset "`rtol` option end-to-end" begin
+            struct TestNodeForRtolOption end
+
+            @node TestNodeForRtolOption Stochastic [out, x]
+
+            # Returns the input scaled by `1 + 1e-4`, i.e. a fixed *relative* error
+            # of 1e-4 regardless of the magnitude of the input.
+            @rule TestNodeForRtolOption(:out, Marginalisation) (m_x::PointMass,) = PointMass(
+                mean(m_x) * (1 + 1e-4)
+            )
+
+            # A huge value, where the 1e-4 relative error is an enormous absolute error.
+            # The default `atol = 1e-6` cannot possibly be satisfied here.
+            let statuses = Bool[]
+                with_logger(SimpleLogger(IOBuffer())) do
+                    ReactiveMP.@test_rules (status) ->
+                        push!(statuses, status) [check_type_promotion = false] TestNodeForRtolOption(
+                        :out, Marginalisation
+                    ) [(
+                        input = (m_x = PointMass(1e10),),
+                        output = PointMass(1e10),
+                    )]
+                end
+                @test statuses == [false]
+            end
+
+            # The same entry passes once a relative tolerance loose enough to cover
+            # the 1e-4 relative error is supplied.
+            let statuses = Bool[]
+                ReactiveMP.@test_rules (status) ->
+                    push!(statuses, status) [
+                    check_type_promotion = false, atol = 0, rtol = 1e-3
+                ] TestNodeForRtolOption(:out, Marginalisation) [(
+                    input = (m_x = PointMass(1e10),),
+                    output = PointMass(1e10),
+                )]
+                @test statuses == [true]
+            end
+
+            # `rtol` is genuinely relative: a tolerance tighter than the rule's
+            # relative error still fails, at any magnitude.
+            let statuses = Bool[]
+                with_logger(SimpleLogger(IOBuffer())) do
+                    ReactiveMP.@test_rules (status) ->
+                        push!(statuses, status) [
+                        check_type_promotion = false, atol = 0, rtol = 1e-6
+                    ] TestNodeForRtolOption(:out, Marginalisation) [
+                        (
+                            input = (m_x = PointMass(1e10),),
+                            output = PointMass(1e10),
+                        ),
+                        (
+                            input = (m_x = PointMass(1e-10),),
+                            output = PointMass(1e-10),
+                        ),
+                    ]
+                end
+                @test statuses == [false, false]
+            end
+
+            # `atol` and `rtol` combine disjunctively: a tiny-magnitude entry that
+            # `rtol` rejects is still accepted when `atol` alone covers it.
+            let statuses = Bool[]
+                ReactiveMP.@test_rules (status) ->
+                    push!(statuses, status) [
+                    check_type_promotion = false, atol = 1e-6, rtol = 1e-9
+                ] TestNodeForRtolOption(:out, Marginalisation) [(
+                    input = (m_x = PointMass(1e-10),),
+                    output = PointMass(1e-10),
+                )]
+                @test statuses == [true]
+            end
+
+            # Per-type `rtol` is honoured, mirroring the `atol` spelling.
+            let statuses = Bool[]
+                ReactiveMP.@test_rules (status) ->
+                    push!(statuses, status) [
+                    check_type_promotion = false,
+                    atol = 0,
+                    rtol = [Float64 => 1e-3],
+                ] TestNodeForRtolOption(:out, Marginalisation) [(
+                    input = (m_x = PointMass(1e10),),
+                    output = PointMass(1e10),
+                )]
+                @test statuses == [true]
+            end
         end
     end
 


### PR DESCRIPTION
Closes #573.

## Problem

`@test_rules` could only be given an absolute tolerance. That makes it awkward to test rules whose inputs are very large or very small: a fixed `atol` is either meaninglessly loose (huge inputs) or impossible to satisfy (tiny inputs). `isapprox` is already called under the hood via `custom_rule_isapprox`, but its `rtol` keyword was not reachable from the macro's option list.

## Change

`rtol` is now accepted in exactly the same spellings as `atol` — a single number, or an array of `Type => value` pairs:

```julia
@test_rules [atol = 0, rtol = 1e-8] SomeNode(:out, Marginalisation) [ ... ]
@test_rules [rtol = [Float64 => 1e-10, Float32 => 1e-5]] SomeNode(:out, Marginalisation) [ ... ]
```

Implementation mirrors the existing `atol` plumbing one-for-one:

- `TestRulesConfiguration` gains a `float_rtolerance::Dict`, with `float_rtolerance` / `float_rtolerance!` accessors matching the three `float_tolerance!` methods (single number, per-type array, individual type).
- `test_rules_parse_configuration` learns the `rtol` key.
- `test_rules_generate_testset` forwards `rtol` to `custom_rule_isapprox` alongside `atol`. Every `custom_rule_isapprox` / `culogpdf__isapprox` method already splats `kwargs...`, so nothing else needed changing.

## Existing tests are numerically unchanged

The default is `0` for every float type. That is not an arbitrary pick: Julia's `rtoldefault(x, y, atol)` already returns zero whenever a positive `atol` is supplied, so passing `rtol = 0` explicitly is precisely what `isapprox` was doing before this change. Both tolerances reach `isapprox`, so they combine disjunctively as

```
|actual - expected| <= max(atol, rtol * max(|actual|, |expected|))
```

To test purely relatively, set `atol = 0` explicitly — this is documented in the `@test_rules` docstring.

## Tests

- Configuration accessors: single number, per-type array, individual type, the zero default, and independence from `atol`.
- Option parsing: `rtol` produces the expected `float_rtolerance!` call; `test_rules_generate_testset` references `float_rtolerance`.
- End-to-end, using a rule with a fixed 1e-4 *relative* error: it **fails** under the default `atol`, **passes** under a loose `rtol`, **fails** again under a tighter `rtol` at both large (`1e10`) and small (`1e-10`) magnitudes, and the disjunctive `atol`/`rtol` combination is pinned too.

Regression gate: with `src/rule.jl` reverted and the new tests in place, `rule_tests.jl` errors — the tests cannot pass without this change.

Full suite (`RUN_AQUA=false make test`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)