### PR TITLE
Normalize CHANGELOG release dates to ISO 8601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added missing `BayesBase` module prefix to `paramfloattype(::ManyOf)` method so the extension is correctly registered ([#606](https://github.com/ReactiveBayes/ReactiveMP.jl/pull/606))
 
-## [6.1.0] - 04-05-2026
+## [6.1.0] - 2026-05-04
 
 ### Added
 - `Base.show` methods for every callback `Event` defined in `src/callbacks.jl` (`Before/AfterMessageRuleCallEvent`, `Before/AfterProductOfTwoMessagesEvent`, `Before/AfterProductOfMessagesEvent`, `Before/AfterFormConstraintAppliedEvent`, `Before/AfterMarginalComputationEvent`) so the RxInfer trace logger no longer dumps raw struct contents into TBLogger text summaries ([#599](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/599), [RxInfer.jl#638](https://github.com/ReactiveBayes/RxInfer.jl/issues/638)). The methods honor the `IOContext` `:compact` flag: trace loggers pass `:compact => true` to get a one-line `nmsgs=N` / 4-char span summary, while REPL/Pluto/Jupyter sees the full form with actual messages and the full UUID span id.
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Base.show(io, ::AnnotationDict)` now switches between the count summary `AnnotationDict(n=K)` and the full key/value listing based on `get(io, :compact, false)` rather than `MIME"text/plain"` dispatch, matching the convention used by the new event show methods
 
-## [6.0.0]
+## [6.0.0] - 2026-04-17
 
 ### Added
 - `AbstractStreamPostprocessor` abstraction unifying the old pipeline stages and the per-node `scheduler` argument under a single concept that postprocesses outbound message streams, marginal streams, and score streams uniformly


### PR DESCRIPTION
Closes #628.

The file header states it follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), which specifies ISO `YYYY-MM-DD` dates, but two headings did not:

- `## [6.1.0] - 04-05-2026` used DD-MM-YYYY → now `2026-05-04`.
- `## [6.0.0]` had **no date at all** → now `2026-04-17`, taken from its `v6.0.0` tag (`Release 6 (#600)`, 2026-04-17).

Every release heading in the file is now ISO-dated; verified with:

```
grep -nE '^## \[' CHANGELOG.md | grep -v 'Unreleased' | grep -vE '\- [0-9]{4}-[0-9]{2}-[0-9]{2}$'
```

which now returns nothing.

Documentation only — no source or behaviour change, so no test accompanies this.

### Note on the rest of #628

The issue also asked for an `## [Unreleased]` entry for the GCV `:ω` mean-field fix. That entry belongs with the fix itself and lands in the GCV PR (#621), not here, so this PR stays a pure date normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)