### PR TITLE
Add test coverage for the GCV message rule family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Test coverage for the `GCV` message rule family, which previously had none — `grep -rn GCV test/` matched nothing, and the only GCV test file exercised the `ExponentialLinearQuadratic` distribution and `prod` without ever calling a message rule. New `test/rules/gcv/` covers `:y`, `:x`, `:z`, `:κ` (mean-field and structured variants), the `:y_x` joint marginal, and both `@average_energy` methods, with expected values derived in-source from the node's likelihood `N(y | x, exp(κz + ω))` rather than captured as golden numbers. Includes cross-method invariants that need no reference values at all: structured variants must reduce to their mean-field siblings at zero `y`–`x` covariance, `:y` and `:x` must agree under the node's `y ↔ x` symmetry, `:κ` and `:z` must agree under `κ ↔ z`, and the joint marginal's off-diagonal coupling must be the reciprocal of the variance the `:y` rule adds. GCV assertions go from 57 (distribution only) to 416 ([#626](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/626))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/test/nodes/predefined/gcv_tests.jl
+++ b/test/nodes/predefined/gcv_tests.jl
@@ -83,3 +83,146 @@
         end
     end
 end
+
+@testitem "GCV: average energy" begin
+    using ReactiveMP, BayesBase, Distributions, ExponentialFamily, StableRNGs
+
+    import ReactiveMP: GCVMetadata, GaussHermiteCubature
+    import StatsFuns: log2π
+
+    # The GCV node is `p(y | x, z, κ, ω) = N(y | x, exp(κz + ω))`, so
+    #
+    #     -log p = ½[log2π + (κz + ω) + (y - x)²·e^{-(κz + ω)}]
+    #
+    # and the average energy ⟨-log p⟩ under a factorized q is
+    #
+    #     ½[log2π + ⟨κ⟩⟨z⟩ + ⟨ω⟩ + ψ·A·B]
+    #
+    # with ψ = ⟨(y - x)²⟩, A = ⟨e^{-ω}⟩ and B the node's Gaussian-moment approximation to
+    # ⟨e^{-κz}⟩ (see test/rules/gcv/gcv_setup_tests.jl for why B is approximate). Written out
+    # here independently of the implementation.
+    function reference_ae(psi, q_z, q_κ, q_ω)
+        m_z, v_z = mean_var(q_z)
+        m_κ, v_κ = mean_var(q_κ)
+        m_ω, v_ω = mean_var(q_ω)
+        ksi = m_κ^2 * v_z + m_z^2 * v_κ + v_κ * v_z
+        A = exp(-m_ω + v_ω / 2)
+        B = exp(-m_κ * m_z + ksi / 2)
+        return (log2π + (m_z * m_κ + m_ω) + psi * A * B) / 2
+    end
+
+    meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) = score(
+        AverageEnergy(),
+        GCV,
+        Val{(:y, :x, :z, :κ, :ω)}(),
+        map(
+            q -> Marginal(q, false, false),
+            (q_y, q_x, q_z, q_κ, q_ω),
+        ),
+        GCVMetadata(GaussHermiteCubature(20)),
+    )
+
+    structured_ae(q_y_x, q_z, q_κ, q_ω) = score(
+        AverageEnergy(),
+        GCV,
+        Val{(:y_x, :z, :κ, :ω)}(),
+        map(
+            q -> Marginal(q, false, false),
+            (q_y_x, q_z, q_κ, q_ω),
+        ),
+        GCVMetadata(GaussHermiteCubature(20)),
+    )
+
+    parameter_sets = (
+        (
+            NormalMeanVariance(3.0, 1.0),
+            NormalMeanVariance(1.0, 2.0),
+            NormalMeanVariance(0.5, 0.7),
+            NormalMeanVariance(0.8, 0.4),
+            NormalMeanVariance(1.2, 0.5),
+        ),
+        (
+            NormalMeanVariance(0.4, 0.6),
+            NormalMeanVariance(0.5, 0.3),
+            NormalMeanVariance(2.0, 0.3),
+            NormalMeanVariance(1.2, 0.25),
+            NormalMeanVariance(-0.5, 0.8),
+        ),
+        (
+            NormalMeanVariance(-1.5, 0.25),
+            NormalMeanVariance(2.5, 0.5),
+            NormalMeanVariance(-0.75, 1.25),
+            NormalMeanVariance(0.3, 0.9),
+            NormalMeanVariance(0.6, 0.15),
+        ),
+    )
+
+    @testset "Mean-field variant against the derived reference" begin
+        for (q_y, q_x, q_z, q_κ, q_ω) in parameter_sets
+            psi =
+                (mean(q_y) - mean(q_x))^2 + var(q_y) + var(q_x)
+            @test meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) ≈
+                reference_ae(psi, q_z, q_κ, q_ω)
+        end
+    end
+
+    @testset "Structured variant against the derived reference" begin
+        for (q_y, q_x, q_z, q_κ, q_ω) in parameter_sets
+            V = [var(q_y) 0.3; 0.3 var(q_x)]
+            q_y_x = MvNormalMeanCovariance([mean(q_y), mean(q_x)], V)
+            psi =
+                (mean(q_y) - mean(q_x))^2 + V[1, 1] + V[2, 2] - V[1, 2] -
+                V[2, 1]
+            @test structured_ae(q_y_x, q_z, q_κ, q_ω) ≈
+                reference_ae(psi, q_z, q_κ, q_ω)
+        end
+    end
+
+    @testset "The two variants agree at zero y-x covariance" begin
+        # With Cov(y, x) = 0 the structured q(y, x) carries exactly the information of the
+        # factorized pair, so the two @average_energy methods must agree. This is the same
+        # invariant that caught the softdot mean-field bug in #615.
+        for (q_y, q_x, q_z, q_κ, q_ω) in parameter_sets
+            q_y_x = MvNormalMeanCovariance(
+                [mean(q_y), mean(q_x)], [var(q_y) 0.0; 0.0 var(q_x)]
+            )
+            @test meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) ≈
+                structured_ae(q_y_x, q_z, q_κ, q_ω)
+        end
+    end
+
+    @testset "Reduces to the Gaussian entropy term for a deterministic unit variance" begin
+        # If κz + ω is pinned to 0, the likelihood collapses to N(y | x, 1) and the average
+        # energy must reduce to ½[log2π + ⟨(y-x)²⟩] -- the plain Gaussian cross-entropy.
+        q_y = NormalMeanVariance(3.0, 1.0)
+        q_x = NormalMeanVariance(1.0, 2.0)
+        # `q_z` must be a `NormalDistributionsFamily` per the rule signature; a zero-variance
+        # Normal is the degenerate member of that family. `q_κ`/`q_ω` are typed `Any`.
+        q_z = NormalMeanVariance(0.0, 0.0)
+        q_κ = PointMass(0.0)
+        q_ω = PointMass(0.0)
+
+        psi = (3.0 - 1.0)^2 + 1.0 + 2.0
+        @test meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) ≈ (log2π + psi) / 2
+    end
+
+    @testset "Monte Carlo confirmation of the exactly-computable part" begin
+        # With κ = z = 0 the only stochastic term left is ω, whose contribution
+        # ⟨ω⟩ + ψ·⟨e^{-ω}⟩ is exact (no Gaussian-moment approximation is involved). Confirms
+        # the average energy against sampling rather than against a rearranged formula.
+        rng = StableRNG(42)
+        q_y = NormalMeanVariance(3.0, 1.0)
+        q_x = NormalMeanVariance(1.0, 2.0)
+        q_z = NormalMeanVariance(0.0, 0.0)
+        q_κ = PointMass(0.0)
+        q_ω = NormalMeanVariance(0.7, 0.4)
+
+        psi = (3.0 - 1.0)^2 + 1.0 + 2.0
+        ω_samples = rand(rng, Normal(0.7, sqrt(0.4)), 10^6)
+        mc = mean(
+            @. (log2π + ω_samples + psi * exp(-ω_samples)) / 2
+        )
+
+        @test meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) ≈ mc rtol = 5e-3
+    end
+end

--- a/test/nodes/predefined/gcv_tests.jl
+++ b/test/nodes/predefined/gcv_tests.jl
@@ -115,10 +115,7 @@ end
         AverageEnergy(),
         GCV,
         Val{(:y, :x, :z, :κ, :ω)}(),
-        map(
-            q -> Marginal(q, false, false),
-            (q_y, q_x, q_z, q_κ, q_ω),
-        ),
+        map(q -> Marginal(q, false, false), (q_y, q_x, q_z, q_κ, q_ω)),
         GCVMetadata(GaussHermiteCubature(20)),
     )
 
@@ -126,10 +123,7 @@ end
         AverageEnergy(),
         GCV,
         Val{(:y_x, :z, :κ, :ω)}(),
-        map(
-            q -> Marginal(q, false, false),
-            (q_y_x, q_z, q_κ, q_ω),
-        ),
+        map(q -> Marginal(q, false, false), (q_y_x, q_z, q_κ, q_ω)),
         GCVMetadata(GaussHermiteCubature(20)),
     )
 
@@ -159,8 +153,7 @@ end
 
     @testset "Mean-field variant against the derived reference" begin
         for (q_y, q_x, q_z, q_κ, q_ω) in parameter_sets
-            psi =
-                (mean(q_y) - mean(q_x))^2 + var(q_y) + var(q_x)
+            psi = (mean(q_y) - mean(q_x))^2 + var(q_y) + var(q_x)
             @test meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) ≈
                 reference_ae(psi, q_z, q_κ, q_ω)
         end
@@ -219,9 +212,7 @@ end
 
         psi = (3.0 - 1.0)^2 + 1.0 + 2.0
         ω_samples = rand(rng, Normal(0.7, sqrt(0.4)), 10^6)
-        mc = mean(
-            @. (log2π + ω_samples + psi * exp(-ω_samples)) / 2
-        )
+        mc = mean(@. (log2π + ω_samples + psi * exp(-ω_samples)) / 2)
 
         @test meanfield_ae(q_y, q_x, q_z, q_κ, q_ω) ≈ mc rtol = 5e-3
     end

--- a/test/rules/gcv/gcv_setup_tests.jl
+++ b/test/rules/gcv/gcv_setup_tests.jl
@@ -1,0 +1,91 @@
+@testmodule GCVRulesTestUtils begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    import ReactiveMP:
+        ExponentialLinearQuadratic, GCVMetadata, GaussHermiteCubature
+
+    # The `GCV` node is `p(y | x, z, κ, ω) = N(y | x, exp(κz + ω))` -- the *variance* is
+    # `exp(κz + ω)`, so the precision is `exp(-(κz + ω))`. Everything in these test files is
+    # derived from that single statement, which is pinned independently by the node's own
+    # `@average_energy`:
+    #
+    #     -log p = ½[log2π + (κz + ω) + (y - x)²·e^{-(κz + ω)}]
+    #
+    # Two expectations recur throughout. Only the first is exact:
+    #
+    #   A = ⟨e^{-ω}⟩  -- EXACT for ω ~ N(m, v): the mean of a lognormal, exp(-m + v/2).
+    #
+    #   B = ⟨e^{-κz}⟩ -- an APPROXIMATION. `κz` is a product of two Gaussians and is not
+    #                    itself Gaussian, but the node treats it as such and applies the
+    #                    same lognormal formula using Var(κz) = ⟨κ⟩²Var(z) + ⟨z⟩²Var(κ) +
+    #                    Var(κ)Var(z). This is a deliberate modelling choice of the node,
+    #                    not a defect, so the tests below reproduce it rather than
+    #                    comparing against the true expectation.
+    #
+    # `A` is verified against an independent Monte Carlo estimate in `shared_tests.jl`;
+    # `B`'s status as an approximation is documented there too.
+
+    # Exact: mean of the lognormal e^{-ω} for ω ~ N(m_ω, v_ω)
+    expected_A(q_ω) = ((m, v) = mean_var(q_ω); exp(-m + v / 2))
+
+    # The node's Gaussian-moment approximation to ⟨e^{-κz}⟩
+    function expected_B(q_z, q_κ)
+        m_z, v_z = mean_var(q_z)
+        m_κ, v_κ = mean_var(q_κ)
+        var_κz = m_κ^2 * v_z + m_z^2 * v_κ + v_κ * v_z
+        return exp(-m_κ * m_z + var_κz / 2)
+    end
+
+    # ⟨(y - x)²⟩ under a factorized q(y)q(x)
+    expected_psi(q_y, q_x) =
+        let (m_y, v_y) = mean_var(q_y), (m_x, v_x) = mean_var(q_x)
+            (m_y - m_x)^2 + v_y + v_x
+        end
+
+    # ⟨(y - x)²⟩ under a joint q(y, x); equals the factorized form when Cov(y, x) = 0
+    function expected_psi(q_y_x)
+        m, V = mean_cov(q_y_x)
+        return (m[1] - m[2])^2 + V[1, 1] + V[2, 2] - V[1, 2] - V[2, 1]
+    end
+
+    coefficients(d::ExponentialLinearQuadratic) = (d.a, d.b, d.c, d.d)
+
+    # A joint q(y, x) with zero cross-covariance, i.e. the factorized case embedded in the
+    # structured parameterisation. Every structured rule must then agree exactly with its
+    # mean-field sibling.
+    block_diagonal_joint(q_y, q_x) =
+        let (m_y, v_y) = mean_var(q_y), (m_x, v_x) = mean_var(q_x)
+            MvNormalMeanCovariance([m_y, m_x], [v_y 0.0; 0.0 v_x])
+        end
+
+    default_meta() = GCVMetadata(GaussHermiteCubature(20))
+
+    # A spread of parameter sets used across the rule test files. `z` and `κ` deliberately
+    # get means away from 0 and 1 and non-zero variances -- degenerate choices such as
+    # ⟨z⟩ = 1, Var(z) = 0 mask coefficient mix-ups between the `:ω`, `:κ` and `:z` rules.
+    function parameter_sets()
+        return (
+            (
+                q_y = NormalMeanVariance(3.0, 1.0),
+                q_x = NormalMeanVariance(1.0, 2.0),
+                q_z = NormalMeanVariance(0.5, 0.7),
+                q_κ = NormalMeanVariance(0.8, 0.4),
+                q_ω = NormalMeanVariance(1.2, 0.5),
+            ),
+            (
+                q_y = NormalMeanVariance(0.4, 0.6),
+                q_x = NormalMeanVariance(0.5, 0.3),
+                q_z = NormalMeanVariance(2.0, 0.3),
+                q_κ = NormalMeanVariance(1.2, 0.25),
+                q_ω = NormalMeanVariance(-0.5, 0.8),
+            ),
+            (
+                q_y = NormalMeanVariance(-1.5, 0.25),
+                q_x = NormalMeanVariance(2.5, 0.5),
+                q_z = NormalMeanVariance(-0.75, 1.25),
+                q_κ = NormalMeanVariance(0.3, 0.9),
+                q_ω = NormalMeanVariance(0.6, 0.15),
+            ),
+        )
+    end
+end

--- a/test/rules/gcv/k_tests.jl
+++ b/test/rules/gcv/k_tests.jl
@@ -42,8 +42,7 @@
 
             @test msg isa ExponentialLinearQuadratic
             @test all(
-                coefficients(msg) .≈
-                reference(expected_psi(q_y, q_x), q_z, q_ω)
+                coefficients(msg) .≈ reference(expected_psi(q_y, q_x), q_z, q_ω)
             )
             # `a` and `c` are equal and opposite by construction.
             @test msg.a ≈ -msg.c

--- a/test/rules/gcv/k_tests.jl
+++ b/test/rules/gcv/k_tests.jl
@@ -1,0 +1,110 @@
+
+@testitem "rules:GCV:κ" setup = [GCVRulesTestUtils] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    import ReactiveMP: ExponentialLinearQuadratic
+
+    expected_A     = GCVRulesTestUtils.expected_A
+    expected_psi   = GCVRulesTestUtils.expected_psi
+    coefficients   = GCVRulesTestUtils.coefficients
+    default_meta   = GCVRulesTestUtils.default_meta
+    parameter_sets = GCVRulesTestUtils.parameter_sets
+
+    # Keeping only the `κ`-dependent terms of `-log p = ½[log2π + (κz + ω) + ψ·e^{-(κz+ω)}]`
+    # and marginalising `y, x, z, ω`:
+    #
+    #     -log f(κ) = ½[⟨z⟩·κ + ψ·⟨e^{-ω}⟩·⟨e^{-κz}⟩_z] + const
+    #
+    # where the inner expectation is over `z` only, with `κ` still free:
+    #
+    #     ⟨e^{-κz}⟩_z = exp(-κ⟨z⟩ + κ²Var(z)/2)     (exact: z is Gaussian, κ is a constant here)
+    #
+    # Matching `logpdf = -(a·κ + b·exp(c·κ + d·κ²/2))/2` term by term:
+    #
+    #     a = ⟨z⟩,   b = ψ·A,   c = -⟨z⟩,   d = Var(z)
+    #
+    # Note this expectation *is* exact, unlike the `B` used by the `:y`/`:x`/`:ω` rules --
+    # here only `z` is integrated out and `κ` remains a free variable of the message.
+    function reference(psi, q_z, q_ω)
+        m_z, v_z = mean_var(q_z)
+        return (m_z, psi * expected_A(q_ω), -m_z, v_z)
+    end
+
+    meta = default_meta()
+
+    @testset "Mean-field: (q_y, q_x, q_z, q_ω)" begin
+        for params in parameter_sets()
+            (; q_y, q_x, q_z, q_ω) = params
+
+            msg = @call_rule GCV(:κ, Marginalisation) (
+                q_y = q_y, q_x = q_x, q_z = q_z, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa ExponentialLinearQuadratic
+            @test all(
+                coefficients(msg) .≈
+                reference(expected_psi(q_y, q_x), q_z, q_ω)
+            )
+            # `a` and `c` are equal and opposite by construction.
+            @test msg.a ≈ -msg.c
+        end
+    end
+
+    @testset "Structured: (q_y_x, q_z, q_ω)" begin
+        for (m, V) in (
+            ([3.0, 1.0], [1.0 0.3; 0.3 2.0]),
+            ([-1.5, 2.5], [0.25 -0.1; -0.1 0.5]),
+        )
+            q_y_x = MvNormalMeanCovariance(m, V)
+            (; q_z, q_ω) = first(parameter_sets())
+
+            msg = @call_rule GCV(:κ, Marginalisation) (
+                q_y_x = q_y_x, q_z = q_z, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa ExponentialLinearQuadratic
+            @test all(
+                coefficients(msg) .≈ reference(expected_psi(q_y_x), q_z, q_ω)
+            )
+            @test msg.a ≈ -msg.c
+        end
+    end
+
+    @testset "The y-x covariance enters only through ψ" begin
+        # `ψ = ⟨(y-x)²⟩ = ⟨y-x⟩² + Var(y) + Var(x) - 2Cov(y,x)`, so a positive covariance
+        # *reduces* ψ and hence `b`, while leaving `a`, `c`, `d` untouched. This pins that the
+        # structured method routes the covariance to the right place.
+        (; q_z, q_ω) = first(parameter_sets())
+        m = [3.0, 1.0]
+
+        uncorrelated = @call_rule GCV(:κ, Marginalisation) (
+            q_y_x = MvNormalMeanCovariance(m, [1.0 0.0; 0.0 2.0]),
+            q_z = q_z,
+            q_ω = q_ω,
+            meta = meta,
+        )
+        correlated = @call_rule GCV(:κ, Marginalisation) (
+            q_y_x = MvNormalMeanCovariance(m, [1.0 0.5; 0.5 2.0]),
+            q_z = q_z,
+            q_ω = q_ω,
+            meta = meta,
+        )
+
+        @test correlated.b < uncorrelated.b
+        @test (correlated.a, correlated.c, correlated.d) ==
+            (uncorrelated.a, uncorrelated.c, uncorrelated.d)
+        # ψ drops by exactly 2·Cov(y, x) = 1.0, and `b = ψ·A`
+        @test uncorrelated.b - correlated.b ≈ 1.0 * expected_A(q_ω)
+    end
+
+    @testset "Type promotion" begin
+        msg = @call_rule GCV(:κ, Marginalisation) (
+            q_y = NormalMeanVariance(3.0f0, 1.0f0),
+            q_x = NormalMeanVariance(1.0f0, 2.0f0),
+            q_z = NormalMeanVariance(0.5f0, 0.7f0),
+            q_ω = NormalMeanVariance(1.2f0, 0.5f0),
+            meta = meta,
+        )
+        @test eltype(msg) === Float32
+    end
+end

--- a/test/rules/gcv/marginals_tests.jl
+++ b/test/rules/gcv/marginals_tests.jl
@@ -130,9 +130,7 @@
         # A·B = exp(-0.936) as derived in `y_tests.jl`. With m_y = N(3.0, 1.0) and
         # m_x = N(1.0, 2.0): W_y = 1.0, W_x = 0.5, ξ = [3.0, 0.5].
         ab = exp(-0.936)
-        @test_marginalrules [check_type_promotion = true] GCV(
-            :y_x
-        ) [(
+        @test_marginalrules [check_type_promotion = true] GCV(:y_x) [(
             input = (
                 m_y = NormalMeanVariance(3.0, 1.0),
                 m_x = NormalMeanVariance(1.0, 2.0),
@@ -158,12 +156,7 @@
         m_x, w_x = mean_precision(q_x)
 
         joint = @call_marginalrule GCV(:y_x) (
-            m_y = elq,
-            m_x = q_x,
-            q_z = q_z,
-            q_κ = q_κ,
-            q_ω = q_ω,
-            meta = meta,
+            m_y = elq, m_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
         )
 
         @test joint isa MvNormalWeightedMeanPrecision

--- a/test/rules/gcv/marginals_tests.jl
+++ b/test/rules/gcv/marginals_tests.jl
@@ -1,0 +1,173 @@
+
+@testitem "marginalrules:GCV:y_x" setup = [GCVRulesTestUtils] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions, LinearAlgebra
+
+    import ReactiveMP:
+        @test_marginalrules, ExponentialLinearQuadratic, GaussHermiteCubature
+
+    expected_A     = GCVRulesTestUtils.expected_A
+    expected_B     = GCVRulesTestUtils.expected_B
+    default_meta   = GCVRulesTestUtils.default_meta
+    parameter_sets = GCVRulesTestUtils.parameter_sets
+
+    # The joint `q(y, x)` combines the two incoming messages with the factor
+    # `N(y | x, exp(κz + ω))`. Writing the factor's exponent in terms of `(y, x)` with the
+    # effective noise precision `AB = ⟨e^{-(κz+ω)}⟩`:
+    #
+    #     -½·AB·(y - x)²  ⇒  precision contribution  [ AB  -AB ; -AB  AB ]
+    #
+    # Adding the incoming messages' own precisions on the diagonal, and their weighted means
+    # as the natural parameter:
+    #
+    #     W = [ W_y + AB   -AB      ]        ξ = [ ⟨y⟩·W_y ]
+    #         [ -AB        W_x + AB ]            [ ⟨x⟩·W_x ]
+    #
+    # The off-diagonal is the *only* place the two variables couple, and it is exactly the
+    # negated noise precision -- which is also the reciprocal of the variance the `:y`/`:x`
+    # rules add. That cross-consistency is asserted below.
+    meta = default_meta()
+
+    @testset "Against the derived weighted-mean/precision form" begin
+        for params in parameter_sets()
+            (; q_y, q_x, q_z, q_κ, q_ω) = params
+            m_y, w_y = mean_precision(q_y)
+            m_x, w_x = mean_precision(q_x)
+            ab = expected_A(q_ω) * expected_B(q_z, q_κ)
+
+            result = @call_marginalrule GCV(:y_x) (
+                m_y = q_y,
+                m_x = q_x,
+                q_z = q_z,
+                q_κ = q_κ,
+                q_ω = q_ω,
+                meta = meta,
+            )
+
+            @test result isa MvNormalWeightedMeanPrecision
+            @test weightedmean(result) ≈ [m_y * w_y, m_x * w_x]
+            @test invcov(result) ≈ [w_y+ab -ab; -ab w_x+ab]
+        end
+    end
+
+    @testset "Off-diagonal coupling is exactly the noise precision" begin
+        # Ties the marginal rule to the `:y` rule: the joint's off-diagonal is `-AB`, and the
+        # variance the `:y` rule adds on top of the incoming variance is `1/AB`. Two different
+        # code paths computing the same effective noise, checked against each other rather than
+        # against a shared reference value.
+        for params in parameter_sets()
+            (; q_y, q_x, q_z, q_κ, q_ω) = params
+
+            joint = @call_marginalrule GCV(:y_x) (
+                m_y = q_y,
+                m_x = q_x,
+                q_z = q_z,
+                q_κ = q_κ,
+                q_ω = q_ω,
+                meta = meta,
+            )
+            to_y = @call_rule GCV(:y, Marginalisation) (
+                m_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            W = invcov(joint)
+            added_variance = var(to_y) - var(q_x)
+
+            @test W[1, 2] ≈ W[2, 1]
+            @test -W[1, 2] ≈ inv(added_variance)
+
+            # The coupling also appears on the diagonal, so each diagonal entry minus the
+            # corresponding incoming precision must equal the same quantity.
+            @test W[1, 1] - precision(q_y) ≈ -W[1, 2]
+            @test W[2, 2] - precision(q_x) ≈ -W[1, 2]
+        end
+    end
+
+    @testset "The joint is a valid, positive-definite Gaussian" begin
+        # `W` is a rank-one coupling added to a positive diagonal, so it must stay PD -- a
+        # sanity property that catches sign errors in the off-diagonal.
+        for params in parameter_sets()
+            (; q_y, q_x, q_z, q_κ, q_ω) = params
+
+            joint = @call_marginalrule GCV(:y_x) (
+                m_y = q_y,
+                m_x = q_x,
+                q_z = q_z,
+                q_κ = q_κ,
+                q_ω = q_ω,
+                meta = meta,
+            )
+
+            @test isposdef(invcov(joint))
+            @test isposdef(cov(joint))
+            # Positive coupling between y and x: observing one informs the other upward.
+            @test cov(joint)[1, 2] > 0
+        end
+    end
+
+    @testset "Marginal means bracket the two incoming means" begin
+        # With a shared noise term pulling `y` and `x` together, each marginal mean must lie
+        # between the two incoming means (inclusive), never outside them.
+        for params in parameter_sets()
+            (; q_y, q_x, q_z, q_κ, q_ω) = params
+
+            joint = @call_marginalrule GCV(:y_x) (
+                m_y = q_y,
+                m_x = q_x,
+                q_z = q_z,
+                q_κ = q_κ,
+                q_ω = q_ω,
+                meta = meta,
+            )
+
+            m = mean(joint)
+            lo, hi = minmax(mean(q_y), mean(q_x))
+            @test lo - 1e-10 <= m[1] <= hi + 1e-10
+            @test lo - 1e-10 <= m[2] <= hi + 1e-10
+        end
+    end
+
+    @testset "Type promotion, against fully worked-out constants" begin
+        # A·B = exp(-0.936) as derived in `y_tests.jl`. With m_y = N(3.0, 1.0) and
+        # m_x = N(1.0, 2.0): W_y = 1.0, W_x = 0.5, ξ = [3.0, 0.5].
+        ab = exp(-0.936)
+        @test_marginalrules [check_type_promotion = true] GCV(
+            :y_x
+        ) [(
+            input = (
+                m_y = NormalMeanVariance(3.0, 1.0),
+                m_x = NormalMeanVariance(1.0, 2.0),
+                q_z = NormalMeanVariance(0.5, 0.7),
+                q_κ = NormalMeanVariance(0.8, 0.4),
+                q_ω = NormalMeanVariance(1.2, 0.5),
+                meta = GCVMetadata(GaussHermiteCubature(20)),
+            ),
+            output = MvNormalWeightedMeanPrecision(
+                [3.0, 0.5], [1.0+ab -ab; -ab 0.5+ab]
+            ),
+        )]
+    end
+
+    @testset "Accepts ExponentialLinearQuadratic incoming messages" begin
+        # Both `m_y` and `m_x` are typed `UniNormalOrExpLinQuad`.
+        (; q_x, q_z, q_κ, q_ω) = first(parameter_sets())
+        elq = ExponentialLinearQuadratic(
+            GaussHermiteCubature(20), 1.0, 1.0, -1.0, 0.0
+        )
+        elq_mean, elq_precision = mean_precision(elq)
+        ab = expected_A(q_ω) * expected_B(q_z, q_κ)
+        m_x, w_x = mean_precision(q_x)
+
+        joint = @call_marginalrule GCV(:y_x) (
+            m_y = elq,
+            m_x = q_x,
+            q_z = q_z,
+            q_κ = q_κ,
+            q_ω = q_ω,
+            meta = meta,
+        )
+
+        @test joint isa MvNormalWeightedMeanPrecision
+        @test weightedmean(joint) ≈ [elq_mean * elq_precision, m_x * w_x]
+        @test invcov(joint) ≈ [elq_precision+ab -ab; -ab w_x+ab]
+    end
+end

--- a/test/rules/gcv/shared_tests.jl
+++ b/test/rules/gcv/shared_tests.jl
@@ -1,0 +1,154 @@
+
+@testitem "rules:GCV: effective noise moments" setup = [GCVRulesTestUtils] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions, StableRNGs
+
+    expected_A     = GCVRulesTestUtils.expected_A
+    expected_B     = GCVRulesTestUtils.expected_B
+    parameter_sets = GCVRulesTestUtils.parameter_sets
+
+    # These two quantities appear in every GCV rule, so it is worth establishing what they
+    # are before testing the rules that consume them.
+
+    @testset "A = ⟨e^{-ω}⟩ is exact, and matches Monte Carlo" begin
+        rng = StableRNG(1234)
+        for params in parameter_sets()
+            q_ω = params.q_ω
+            m, v = mean_var(q_ω)
+
+            # Closed form: the mean of a lognormal.
+            @test expected_A(q_ω) ≈ exp(-m + v / 2)
+
+            # Independent Monte Carlo confirmation that the closed form is the *correct*
+            # expectation and not merely the one the implementation happens to use.
+            # Tolerance is the sampling noise floor for 10^6 draws, not a fudge factor.
+            samples = exp.(-rand(rng, Normal(m, sqrt(v)), 10^6))
+            @test mean(samples) ≈ expected_A(q_ω) rtol = 5e-3
+        end
+    end
+
+    @testset "B = ⟨e^{-κz}⟩ is a documented Gaussian-moment approximation" begin
+        # `κz` is a product of independent Gaussians, so it is not Gaussian and the
+        # lognormal formula does not give its exact exponential moment. The node applies it
+        # anyway, using Var(κz) for the variance. This test documents that gap rather than
+        # asserting the approximation is exact -- if a future change replaced `B` with a
+        # genuinely exact computation, this test would flag it as an intentional decision to
+        # revisit rather than silently passing.
+        rng = StableRNG(5678)
+        params = first(parameter_sets())
+        q_z, q_κ = params.q_z, params.q_κ
+
+        m_z, v_z = mean_var(q_z)
+        m_κ, v_κ = mean_var(q_κ)
+
+        z_samples = rand(rng, Normal(m_z, sqrt(v_z)), 10^6)
+        κ_samples = rand(rng, Normal(m_κ, sqrt(v_κ)), 10^6)
+        truth = mean(exp.(-κ_samples .* z_samples))
+
+        # The approximation reproduces the true variance of the exponent ...
+        @test v_κ * v_z + m_κ^2 * v_z + m_z^2 * v_κ ≈
+            var(κ_samples .* z_samples) rtol = 1e-2
+
+        # ... and lands in the right ballpark, but is not exact.
+        @test expected_B(q_z, q_κ) ≈ truth rtol = 0.2
+        @test !isapprox(expected_B(q_z, q_κ), truth; rtol = 1e-4)
+    end
+end
+
+@testitem "rules:GCV: mean-field and structured variants agree at zero y-x covariance" setup = [
+    GCVRulesTestUtils
+] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    coefficients         = GCVRulesTestUtils.coefficients
+    block_diagonal_joint = GCVRulesTestUtils.block_diagonal_joint
+    default_meta         = GCVRulesTestUtils.default_meta
+    parameter_sets       = GCVRulesTestUtils.parameter_sets
+
+    # With no posterior covariance between `y` and `x`, a structured `q(y, x)` carries exactly
+    # the information of the factorized pair, so every structured rule must reduce to its
+    # mean-field sibling. This needs no reference values at all -- only that the two
+    # implementations agree -- which makes it the cheapest possible guard against the class of
+    # copy-paste defect found in #621.
+    #
+    # The `:ω` case of this invariant lives in `w_tests.jl`, alongside the fix for #621 that it
+    # requires; `:κ` and `:z` are covered here.
+    meta = default_meta()
+
+    for params in parameter_sets()
+        (; q_y, q_x, q_z, q_κ, q_ω) = params
+        q_y_x = block_diagonal_joint(q_y, q_x)
+
+        @testset "κ" begin
+            @test all(
+                coefficients(
+                    @call_rule GCV(:κ, Marginalisation) (
+                        q_y = q_y, q_x = q_x, q_z = q_z, q_ω = q_ω, meta = meta
+                    )
+                ) .≈ coefficients(
+                    @call_rule GCV(:κ, Marginalisation) (
+                        q_y_x = q_y_x, q_z = q_z, q_ω = q_ω, meta = meta
+                    )
+                ),
+            )
+        end
+
+        @testset "z" begin
+            @test all(
+                coefficients(
+                    @call_rule GCV(:z, Marginalisation) (
+                        q_y = q_y, q_x = q_x, q_κ = q_κ, q_ω = q_ω, meta = meta
+                    )
+                ) .≈ coefficients(
+                    @call_rule GCV(:z, Marginalisation) (
+                        q_y_x = q_y_x, q_κ = q_κ, q_ω = q_ω, meta = meta
+                    )
+                ),
+            )
+        end
+    end
+end
+
+@testitem "rules:GCV: the three ExponentialLinearQuadratic rules are mutually distinct" setup = [
+    GCVRulesTestUtils
+] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    default_meta = GCVRulesTestUtils.default_meta
+
+    # `:ω`, `:κ` and `:z` all return an `ExponentialLinearQuadratic` and their bodies look
+    # near-identical, which is exactly how the #621 copy-paste survived review. Their
+    # coefficients encode genuinely different structure:
+    #
+    #   :ω → (1,    ψ·B, -1,    0     )   ω multiplies nothing; constant coefficient
+    #   :κ → (⟨z⟩,  ψ·A, -⟨z⟩,  Var(z))   κ multiplies z
+    #   :z → (⟨κ⟩,  ψ·A, -⟨κ⟩,  Var(κ))   z multiplies κ
+    #
+    # so with `⟨z⟩ ≠ ⟨κ⟩` and `Var(z) ≠ Var(κ)` no two of them may coincide. The `:ω` half of
+    # this check lives in `w_tests.jl` with the #621 fix it requires; `:κ` vs `:z` is here.
+    meta = default_meta()
+
+    q_y = NormalMeanVariance(3.0, 1.0)
+    q_x = NormalMeanVariance(1.0, 2.0)
+    q_z = NormalMeanVariance(0.5, 0.7)
+    q_κ = NormalMeanVariance(0.8, 0.4)
+    q_ω = NormalMeanVariance(1.2, 0.5)
+
+    κ_msg = @call_rule GCV(:κ, Marginalisation) (
+        q_y = q_y, q_x = q_x, q_z = q_z, q_ω = q_ω, meta = meta
+    )
+    z_msg = @call_rule GCV(:z, Marginalisation) (
+        q_y = q_y, q_x = q_x, q_κ = q_κ, q_ω = q_ω, meta = meta
+    )
+
+    shape(d) = (d.a, d.c, d.d)
+
+    @test shape(κ_msg) != shape(z_msg)
+
+    # And each carries the moments of the variable it is *supposed* to have marginalised --
+    # `:κ` integrates out `z`, `:z` integrates out `κ`, so a swap between them is caught here.
+    @test (κ_msg.a, κ_msg.d) == (mean(q_z), var(q_z))
+    @test (z_msg.a, z_msg.d) == (mean(q_κ), var(q_κ))
+
+    # Both share the same `b = ψ·⟨e^{-ω}⟩`, since both marginalise `ω` the same way.
+    @test κ_msg.b ≈ z_msg.b
+end

--- a/test/rules/gcv/x_tests.jl
+++ b/test/rules/gcv/x_tests.jl
@@ -1,0 +1,96 @@
+
+@testitem "rules:GCV:x" setup = [GCVRulesTestUtils] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    import ReactiveMP: @test_rules, ExponentialLinearQuadratic, GaussHermiteCubature
+
+    expected_A     = GCVRulesTestUtils.expected_A
+    expected_B     = GCVRulesTestUtils.expected_B
+    default_meta   = GCVRulesTestUtils.default_meta
+    parameter_sets = GCVRulesTestUtils.parameter_sets
+
+    # Mirror image of the `:y` rule -- see `y_tests.jl` for the derivation. The likelihood
+    # depends on `y` and `x` only through `y - x`, so the two rules are structurally identical
+    # with the roles swapped; the cross-rule symmetry itself is asserted in `y_tests.jl`.
+    meta = default_meta()
+
+    @testset "Belief-propagation-style: (m_y, q_z, q_κ, q_ω)" begin
+        for params in parameter_sets()
+            (; q_y, q_z, q_κ, q_ω) = params
+            m_y_mean, m_y_var = mean_var(q_y)
+            noise_precision = expected_A(q_ω) * expected_B(q_z, q_κ)
+
+            msg = @call_rule GCV(:x, Marginalisation) (
+                m_y = q_y, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa NormalMeanVariance
+            @test mean(msg) ≈ m_y_mean
+            @test var(msg) ≈ m_y_var + inv(noise_precision)
+        end
+    end
+
+    @testset "Variational: (q_y, q_z, q_κ, q_ω)" begin
+        for params in parameter_sets()
+            (; q_y, q_z, q_κ, q_ω) = params
+            noise_precision = expected_A(q_ω) * expected_B(q_z, q_κ)
+
+            msg = @call_rule GCV(:x, Marginalisation) (
+                q_y = q_y, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa NormalMeanVariance
+            @test mean(msg) ≈ mean(q_y)
+            @test var(msg) ≈ inv(noise_precision)
+        end
+    end
+
+    @testset "Type promotion, against fully worked-out constants" begin
+        # Same intermediates as the `:y` type-promotion case (A·B = exp(-0.936)), with
+        # q_y = N(3.0, 1.0) → var = 1.0 + exp(0.936).
+        @test_rules [check_type_promotion = true] GCV(
+            :x, Marginalisation
+        ) [(
+            input = (
+                m_y = NormalMeanVariance(3.0, 1.0),
+                q_z = NormalMeanVariance(0.5, 0.7),
+                q_κ = NormalMeanVariance(0.8, 0.4),
+                q_ω = NormalMeanVariance(1.2, 0.5),
+                meta = GCVMetadata(GaussHermiteCubature(20)),
+            ),
+            output = NormalMeanVariance(3.0, 1.0 + exp(0.936)),
+        )]
+    end
+
+    @testset "The two variants differ by exactly Var(y)" begin
+        for params in parameter_sets()
+            (; q_y, q_z, q_κ, q_ω) = params
+
+            from_message = @call_rule GCV(:x, Marginalisation) (
+                m_y = q_y, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+            from_marginal = @call_rule GCV(:x, Marginalisation) (
+                q_y = q_y, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test mean(from_message) ≈ mean(from_marginal)
+            @test var(from_message) - var(from_marginal) ≈ var(q_y)
+        end
+    end
+
+    @testset "Accepts an ExponentialLinearQuadratic incoming message" begin
+        (; q_z, q_κ, q_ω) = first(parameter_sets())
+        elq = ExponentialLinearQuadratic(
+            GaussHermiteCubature(20), 1.0, 1.0, -1.0, 0.0
+        )
+        elq_mean, elq_var = mean_var(elq)
+
+        msg = @call_rule GCV(:x, Marginalisation) (
+            m_y = elq, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+        )
+
+        @test msg isa NormalMeanVariance
+        @test mean(msg) ≈ elq_mean
+        @test var(msg) ≈ elq_var + inv(expected_A(q_ω) * expected_B(q_z, q_κ))
+    end
+end

--- a/test/rules/gcv/x_tests.jl
+++ b/test/rules/gcv/x_tests.jl
@@ -2,7 +2,8 @@
 @testitem "rules:GCV:x" setup = [GCVRulesTestUtils] begin
     using ReactiveMP, BayesBase, ExponentialFamily, Distributions
 
-    import ReactiveMP: @test_rules, ExponentialLinearQuadratic, GaussHermiteCubature
+    import ReactiveMP:
+        @test_rules, ExponentialLinearQuadratic, GaussHermiteCubature
 
     expected_A     = GCVRulesTestUtils.expected_A
     expected_B     = GCVRulesTestUtils.expected_B
@@ -48,9 +49,7 @@
     @testset "Type promotion, against fully worked-out constants" begin
         # Same intermediates as the `:y` type-promotion case (A·B = exp(-0.936)), with
         # q_y = N(3.0, 1.0) → var = 1.0 + exp(0.936).
-        @test_rules [check_type_promotion = true] GCV(
-            :x, Marginalisation
-        ) [(
+        @test_rules [check_type_promotion = true] GCV(:x, Marginalisation) [(
             input = (
                 m_y = NormalMeanVariance(3.0, 1.0),
                 q_z = NormalMeanVariance(0.5, 0.7),

--- a/test/rules/gcv/y_tests.jl
+++ b/test/rules/gcv/y_tests.jl
@@ -1,0 +1,143 @@
+
+@testitem "rules:GCV:y" setup = [GCVRulesTestUtils] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    import ReactiveMP: @test_rules, ExponentialLinearQuadratic, GaussHermiteCubature
+
+    expected_A     = GCVRulesTestUtils.expected_A
+    expected_B     = GCVRulesTestUtils.expected_B
+    default_meta   = GCVRulesTestUtils.default_meta
+    parameter_sets = GCVRulesTestUtils.parameter_sets
+
+    # `y ~ N(x, exp(κz + ω))`, so the message to `y` convolves the incoming belief about `x`
+    # with the effective noise. The effective noise *precision* is ⟨e^{-(κz+ω)}⟩ = A·B, hence
+    # the added variance is `inv(A·B)`:
+    #
+    #   from a message  m_x:  N(⟨x⟩, Var(x) + 1/(A·B))
+    #   from a marginal q_x:  N(⟨x⟩,          1/(A·B))
+    #
+    # The marginal variant omits `Var(x)` because under structured VMP the incoming `q_x`
+    # marginal already accounts for the backward flow; only its mean is used.
+    meta = default_meta()
+
+    @testset "Belief-propagation-style: (m_x, q_z, q_κ, q_ω)" begin
+        for params in parameter_sets()
+            (; q_x, q_z, q_κ, q_ω) = params
+            m_x_mean, m_x_var = mean_var(q_x)
+            noise_precision = expected_A(q_ω) * expected_B(q_z, q_κ)
+
+            msg = @call_rule GCV(:y, Marginalisation) (
+                m_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa NormalMeanVariance
+            @test mean(msg) ≈ m_x_mean
+            @test var(msg) ≈ m_x_var + inv(noise_precision)
+        end
+    end
+
+    @testset "Variational: (q_x, q_z, q_κ, q_ω)" begin
+        for params in parameter_sets()
+            (; q_x, q_z, q_κ, q_ω) = params
+            noise_precision = expected_A(q_ω) * expected_B(q_z, q_κ)
+
+            msg = @call_rule GCV(:y, Marginalisation) (
+                q_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa NormalMeanVariance
+            @test mean(msg) ≈ mean(q_x)
+            @test var(msg) ≈ inv(noise_precision)
+        end
+    end
+
+    @testset "Type promotion, against fully worked-out constants" begin
+        # One case with every intermediate spelled out, so the reference is auditable without
+        # running the helper functions, and `check_type_promotion` exercises Float32/BigFloat.
+        #
+        #   q_ω = N(1.2, 0.5)  → A    = exp(-1.2 + 0.5/2)                    = exp(-0.95)
+        #   q_z = N(0.5, 0.7)
+        #   q_κ = N(0.8, 0.4)  → ξ    = 0.8²·0.7 + 0.5²·0.4 + 0.7·0.4        = 0.828
+        #                        B    = exp(-0.8·0.5 + 0.828/2)              = exp(0.014)
+        #                        A·B  = exp(-0.95 + 0.014)                   = exp(-0.936)
+        #   q_x = N(1.0, 2.0)  → var  = 2.0 + exp(0.936)
+        @test_rules [check_type_promotion = true] GCV(
+            :y, Marginalisation
+        ) [(
+            input = (
+                m_x = NormalMeanVariance(1.0, 2.0),
+                q_z = NormalMeanVariance(0.5, 0.7),
+                q_κ = NormalMeanVariance(0.8, 0.4),
+                q_ω = NormalMeanVariance(1.2, 0.5),
+                meta = GCVMetadata(GaussHermiteCubature(20)),
+            ),
+            output = NormalMeanVariance(1.0, 2.0 + exp(0.936)),
+        )]
+    end
+
+    @testset "The two variants differ by exactly Var(x)" begin
+        # An exact structural relation between the two methods, independent of the reference
+        # values above: the message-based variant adds the incoming variance, the
+        # marginal-based one does not.
+        for params in parameter_sets()
+            (; q_x, q_z, q_κ, q_ω) = params
+
+            from_message = @call_rule GCV(:y, Marginalisation) (
+                m_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+            from_marginal = @call_rule GCV(:y, Marginalisation) (
+                q_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test mean(from_message) ≈ mean(from_marginal)
+            @test var(from_message) - var(from_marginal) ≈ var(q_x)
+        end
+    end
+
+    @testset "y and x rules are symmetric" begin
+        # The likelihood depends on `y` and `x` only through `y - x`, so the `:y` and `:x`
+        # rules must produce the same message from the same incoming belief.
+        for params in parameter_sets()
+            (; q_x, q_z, q_κ, q_ω) = params
+
+            to_y = @call_rule GCV(:y, Marginalisation) (
+                m_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+            to_x = @call_rule GCV(:x, Marginalisation) (
+                m_y = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test mean(to_y) ≈ mean(to_x)
+            @test var(to_y) ≈ var(to_x)
+
+            to_y_q = @call_rule GCV(:y, Marginalisation) (
+                q_x = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+            to_x_q = @call_rule GCV(:x, Marginalisation) (
+                q_y = q_x, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test mean(to_y_q) ≈ mean(to_x_q)
+            @test var(to_y_q) ≈ var(to_x_q)
+        end
+    end
+
+    @testset "Accepts an ExponentialLinearQuadratic incoming message" begin
+        # `m_x` is typed `UniNormalOrExpLinQuad`, so an `ExponentialLinearQuadratic` -- as
+        # produced by the `:ω`/`:κ`/`:z` rules on a neighbouring edge -- must be accepted and
+        # reduced through its cubature-approximated moments.
+        (; q_z, q_κ, q_ω) = first(parameter_sets())
+        elq = ExponentialLinearQuadratic(
+            GaussHermiteCubature(20), 1.0, 1.0, -1.0, 0.0
+        )
+        elq_mean, elq_var = mean_var(elq)
+
+        msg = @call_rule GCV(:y, Marginalisation) (
+            m_x = elq, q_z = q_z, q_κ = q_κ, q_ω = q_ω, meta = meta
+        )
+
+        @test msg isa NormalMeanVariance
+        @test mean(msg) ≈ elq_mean
+        @test var(msg) ≈ elq_var + inv(expected_A(q_ω) * expected_B(q_z, q_κ))
+    end
+end

--- a/test/rules/gcv/y_tests.jl
+++ b/test/rules/gcv/y_tests.jl
@@ -2,7 +2,8 @@
 @testitem "rules:GCV:y" setup = [GCVRulesTestUtils] begin
     using ReactiveMP, BayesBase, ExponentialFamily, Distributions
 
-    import ReactiveMP: @test_rules, ExponentialLinearQuadratic, GaussHermiteCubature
+    import ReactiveMP:
+        @test_rules, ExponentialLinearQuadratic, GaussHermiteCubature
 
     expected_A     = GCVRulesTestUtils.expected_A
     expected_B     = GCVRulesTestUtils.expected_B
@@ -61,9 +62,7 @@
         #                        B    = exp(-0.8·0.5 + 0.828/2)              = exp(0.014)
         #                        A·B  = exp(-0.95 + 0.014)                   = exp(-0.936)
         #   q_x = N(1.0, 2.0)  → var  = 2.0 + exp(0.936)
-        @test_rules [check_type_promotion = true] GCV(
-            :y, Marginalisation
-        ) [(
+        @test_rules [check_type_promotion = true] GCV(:y, Marginalisation) [(
             input = (
                 m_x = NormalMeanVariance(1.0, 2.0),
                 q_z = NormalMeanVariance(0.5, 0.7),

--- a/test/rules/gcv/z_tests.jl
+++ b/test/rules/gcv/z_tests.jl
@@ -1,0 +1,90 @@
+
+@testitem "rules:GCV:z" setup = [GCVRulesTestUtils] begin
+    using ReactiveMP, BayesBase, ExponentialFamily, Distributions
+
+    import ReactiveMP: ExponentialLinearQuadratic
+
+    expected_A     = GCVRulesTestUtils.expected_A
+    expected_psi   = GCVRulesTestUtils.expected_psi
+    coefficients   = GCVRulesTestUtils.coefficients
+    default_meta   = GCVRulesTestUtils.default_meta
+    parameter_sets = GCVRulesTestUtils.parameter_sets
+
+    # Exactly the `:κ` derivation with the roles of `κ` and `z` exchanged -- the likelihood
+    # depends on them only through the product `κz`, so the two rules are mirror images:
+    #
+    #     -log f(z) = ½[⟨κ⟩·z + ψ·⟨e^{-ω}⟩·exp(-z⟨κ⟩ + z²Var(κ)/2)] + const
+    #
+    # giving `a = ⟨κ⟩`, `b = ψ·A`, `c = -⟨κ⟩`, `d = Var(κ)`.
+    function reference(psi, q_κ, q_ω)
+        m_κ, v_κ = mean_var(q_κ)
+        return (m_κ, psi * expected_A(q_ω), -m_κ, v_κ)
+    end
+
+    meta = default_meta()
+
+    @testset "Mean-field: (q_y, q_x, q_κ, q_ω)" begin
+        for params in parameter_sets()
+            (; q_y, q_x, q_κ, q_ω) = params
+
+            msg = @call_rule GCV(:z, Marginalisation) (
+                q_y = q_y, q_x = q_x, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa ExponentialLinearQuadratic
+            @test all(
+                coefficients(msg) .≈
+                reference(expected_psi(q_y, q_x), q_κ, q_ω)
+            )
+            @test msg.a ≈ -msg.c
+        end
+    end
+
+    @testset "Structured: (q_y_x, q_κ, q_ω)" begin
+        for (m, V) in (
+            ([3.0, 1.0], [1.0 0.3; 0.3 2.0]),
+            ([-1.5, 2.5], [0.25 -0.1; -0.1 0.5]),
+        )
+            q_y_x = MvNormalMeanCovariance(m, V)
+            (; q_κ, q_ω) = first(parameter_sets())
+
+            msg = @call_rule GCV(:z, Marginalisation) (
+                q_y_x = q_y_x, q_κ = q_κ, q_ω = q_ω, meta = meta
+            )
+
+            @test msg isa ExponentialLinearQuadratic
+            @test all(
+                coefficients(msg) .≈ reference(expected_psi(q_y_x), q_κ, q_ω)
+            )
+            @test msg.a ≈ -msg.c
+        end
+    end
+
+    @testset "z and κ rules are mirror images under swapping their beliefs" begin
+        # Because the likelihood sees only the product `κz`, feeding belief `d` as `q_κ` to the
+        # `:z` rule must give the same message as feeding `d` as `q_z` to the `:κ` rule.
+        for params in parameter_sets()
+            (; q_y, q_x, q_z, q_ω) = params
+
+            to_z = @call_rule GCV(:z, Marginalisation) (
+                q_y = q_y, q_x = q_x, q_κ = q_z, q_ω = q_ω, meta = meta
+            )
+            to_κ = @call_rule GCV(:κ, Marginalisation) (
+                q_y = q_y, q_x = q_x, q_z = q_z, q_ω = q_ω, meta = meta
+            )
+
+            @test all(coefficients(to_z) .≈ coefficients(to_κ))
+        end
+    end
+
+    @testset "Type promotion" begin
+        msg = @call_rule GCV(:z, Marginalisation) (
+            q_y = NormalMeanVariance(3.0f0, 1.0f0),
+            q_x = NormalMeanVariance(1.0f0, 2.0f0),
+            q_κ = NormalMeanVariance(0.8f0, 0.4f0),
+            q_ω = NormalMeanVariance(1.2f0, 0.5f0),
+            meta = meta,
+        )
+        @test eltype(msg) === Float32
+    end
+end

--- a/test/rules/gcv/z_tests.jl
+++ b/test/rules/gcv/z_tests.jl
@@ -33,8 +33,7 @@
 
             @test msg isa ExponentialLinearQuadratic
             @test all(
-                coefficients(msg) .≈
-                reference(expected_psi(q_y, q_x), q_κ, q_ω)
+                coefficients(msg) .≈ reference(expected_psi(q_y, q_x), q_κ, q_ω)
             )
             @test msg.a ≈ -msg.c
         end


### PR DESCRIPTION
Addresses #626.

## Problem

The `GCV` message rules had **no direct coverage whatsoever**:

```
$ grep -rn "GCV" test/          # nothing
$ ls test/rules/ | grep gcv     # no such directory
```

The one GCV test file (`test/nodes/predefined/gcv_tests.jl`) exercised the `ExponentialLinearQuadratic` distribution and its `prod`, but never called a message rule. That is precisely how the mean-field `:ω` copy-paste (#621) shipped undetected.

## Change

New `test/rules/gcv/` covering `:y`, `:x`, `:z`, `:κ` in both mean-field and structured forms, the `:y_x` joint marginal, and both `@average_energy` methods.

Every expected value is **derived in-source** from the node's likelihood `N(y | x, exp(κz + ω))` — which the node's own `@average_energy` independently pins — rather than captured as a golden number. The derivations are written out in comments so a reader can audit them without running the code.

### The checks that carry the most weight need no reference values at all

They assert that two independent code paths agree, so they cannot be defeated by a reference that was mis-derived in the same direction as a bug:

- **Structured reduces to mean-field at `Cov(y, x) = 0`** — the invariant #621 violated.
- **`:y` ≡ `:x` under `y ↔ x`**, and **`:κ` ≡ `:z` under `κ ↔ z`** — the likelihood sees only `y - x` and the product `κz`.
- **The `:y_x` marginal's off-diagonal coupling is the reciprocal of the variance the `:y` rule adds** — two code paths computing the same effective noise precision.
- **The two `@average_energy` methods agree at zero covariance** — the same invariant that caught the softdot bug in #615.
- **`:κ` and `:z` must not coincide**, and each must carry the moments of the variable it actually marginalised.

Plus structural properties: the joint precision stays positive-definite, the marginal means bracket the two incoming means, and both `ExponentialLinearQuadratic` rules satisfy `a = -c` by construction.

### Two node behaviours now documented by tests rather than left implicit

`shared_tests.jl` establishes what the recurring expectations actually are:

- `A = ⟨e^{-ω}⟩` is **exact** — the mean of a lognormal — confirmed against an independent Monte Carlo estimate.
- `B = ⟨e^{-κz}⟩` is a **deliberate Gaussian-moment approximation**. `κz` is a product of independent Gaussians and is not itself Gaussian, so the lognormal formula does not give its exact exponential moment. The test asserts the approximation is in the right ballpark **and explicitly that it is not exact**, so a future change to an exact computation surfaces as a decision to revisit rather than passing silently.

## Scope note

The `:ω` rule's coverage is **not** here — it lives in `test/rules/gcv/w_tests.jl` on #641, together with the fix it depends on. This PR is based on `main` and is green on `main` as-is, so the two can merge in either order. Once both land, `w_tests.jl` and `shared_tests.jl` are complementary and cross-reference each other in comments.

## Result

GCV assertions go from **57** (distribution only) to **416**, all passing:

```
test/rules/gcv/y_tests.jl          |  85
test/rules/gcv/x_tests.jl          |  73
test/rules/gcv/k_tests.jl          |  19
test/rules/gcv/z_tests.jl          |  19
test/rules/gcv/shared_tests.jl     |  19
test/rules/gcv/marginals_tests.jl  | 133
test/nodes/predefined/gcv_tests.jl |  68
```

Tests only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)