### PR TITLE
Remove dead code from the 2-interface DiscreteTransition(:in) rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The 2-interface `DiscreteTransition(:in)` rule for `PointMass` inputs now uses `softmax!` like the twenty sibling rules in the same file, instead of `exp.` followed by `normalize!`, and two lines of unreachable code after its `return` have been removed. Output is unchanged — `clamplog` bounds the log values from below and the `probvec`-weighted average pulls them toward zero, so both formulations agree on any reachable input; this is a dead-code and consistency cleanup, not a bug fix ([#627](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/627))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/rules/discrete_transition/predefined/structured_vmp.jl
+++ b/src/rules/discrete_transition/predefined/structured_vmp.jl
@@ -8,8 +8,6 @@ using Tullio
 ) where {T} = begin
     eloga = mean(Base.Broadcast.BroadcastFunction(clamplog), q_a)
     out = eloga' * probvec(q_out)
-    out .= exp.(out)
-    return Categorical(normalize!(out, 1); check_args = false)
     softmax!(out)
     return Categorical(out; check_args = false)
 end

--- a/test/rules/discrete_transition/in_tests.jl
+++ b/test/rules/discrete_transition/in_tests.jl
@@ -44,6 +44,48 @@ end
     )]
 end
 
+@testitem "rules:DiscreteTransition:in: 2-interface PointMass rule matches exp-then-normalise" begin
+    using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
+
+    # This rule computes `eloga' * probvec(q_out)` -- a vector of unnormalised *log*
+    # probabilities -- and then converts it to a probability vector. It used to do that with
+    # `out .= exp.(out); normalize!(out, 1)` while all twenty sibling rules in the same file
+    # used `softmax!`, and it carried two lines of unreachable code after its `return`
+    # (issue #627). It now uses `softmax!` like its siblings.
+    #
+    # `softmax!` subtracts the maximum before exponentiating, so it is the more defensive
+    # formulation in general. It is worth being precise about the benefit here, though: with
+    # `clamplog` bounding the log values from below and the subsequent `probvec`-weighted
+    # average pulling them toward zero, this particular rule's inputs stay in a range where
+    # both formulations agree -- including at extreme `q_a` scales. So this is a dead-code and
+    # consistency change, not a bug fix, and this test pins that the output is unchanged.
+    @testset "agrees with the naive form across a wide range of q_a scales" begin
+        q_out = PointMass([0.1, 0.4, 0.5])
+
+        for q_a in (
+            PointMass([0.2 0.4 0.1; 0.1 0.3 0.6; 0.7 0.3 0.3]),
+            PointMass([1e-8 1.0 1.0; 1.0 1e-8 1.0; 1.0 1.0 1e-8]),
+            PointMass([1e8 1.0 1.0; 1.0 1e8 1.0; 1.0 1.0 1e8]),
+            PointMass(diageye(3) .+ tiny),
+        )
+            eloga = mean(
+                Base.Broadcast.BroadcastFunction(ReactiveMP.clamplog), q_a
+            )
+            naive = exp.(eloga' * probvec(q_out))
+            naive ./= sum(naive)
+
+            msg = @call_rule DiscreteTransition(:in, Marginalisation) (
+                q_out = q_out, q_a = q_a
+            )
+
+            p = probvec(msg)
+            @test p ≈ naive
+            @test all(isfinite, p)
+            @test sum(p) ≈ 1
+        end
+    end
+end
+
 @testitem "rules:DiscreteTransition:in:Variational Bayes: (m_out::Categorical, q_a::DirichletCollection)" begin
     using ReactiveMP, BayesBase, Random, ExponentialFamily, Distributions
 


### PR DESCRIPTION
Closes #627.

## Problem

`src/rules/discrete_transition/predefined/structured_vmp.jl` had two unreachable lines after an unconditional `return`:

```julia
out .= exp.(out)
return Categorical(normalize!(out, 1); check_args = false)   # returns here
softmax!(out)                                                # DEAD
return Categorical(out; check_args = false)                   # DEAD
```

It was also the only rule in a file of twenty-one using `exp.` + `normalize!` rather than `softmax!`.

## Change

Deleted the dead lines and kept the `softmax!` form, matching every sibling.

## On the "numerical stability" framing — I checked, and it does not apply here

`softmax!` subtracts the maximum before exponentiating, so it is the more defensive formulation in general, and it would be easy to sell this as a stability fix. It isn't one, and I want to be accurate about that.

I wrote a test that pushed `q_a` to `1e±300` expecting the old form to overflow. **It passed on both versions.** The reason: `clamplog` bounds the log values from below, and the subsequent `probvec`-weighted average (weights summing to 1) pulls them back toward zero, so the exponent stays comfortably inside `exp`'s safe range on any input this rule can actually receive. I could not construct a reachable case where the two formulations differ.

So this is a **dead-code and consistency cleanup with no behavioural change**, and the CHANGELOG entry says exactly that rather than overclaiming.

## Verification

- The pre-existing `(q_out::PointMass, q_a::PointMass)` rule test passes **unchanged** — the primary evidence that output is identical.
- Added a test asserting agreement with the explicit exp-then-normalise computation across four `q_a` scales from `1e-8` to `1e8`, plus finiteness and normalisation, so the equivalence is pinned rather than assumed.
- The full `discrete_transition/in` testset passes (12 new assertions, 27 pre-existing).

Since there is no behaviour change, there is deliberately **no** failing-before/passing-after regression gate to report here — that would only exist if the change fixed something, and it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)