### PR TITLE
Rewrite stale 'WRONG' marker in the BIFM input rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Rewrote the stale `# calculate marginals of input WRONG` marker in `src/rules/bifm/in.jl` to `# calculate the marginal of the input`. The marker was appended by the 2021 commit that *fixed* that rule (`edf799f4`, "fix BIFM input update rule"), most likely as a note that the previous formulation had been wrong, and read as a standing warning that the current rule is defective. Comment only — no behaviour change, and no claim either way about the rule's correctness ([#638](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/638))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/rules/bifm/in.jl
+++ b/src/rules/bifm/in.jl
@@ -23,7 +23,7 @@
     Λtildex = Λztilde - Λztilde * A * Σ_zprev * A' * Λztilde
     tmp = B * Σu
 
-    # calculate marginals of input WRONG
+    # calculate the marginal of the input
     μ_in = μu - (Σu * (B' * ξtildex))
     Σ_in = Σu - tmp' * Λtildex * tmp
 


### PR DESCRIPTION
Closes #638.

`src/rules/bifm/in.jl:26` carried

```julia
# calculate marginals of input WRONG
μ_in = μu - (Σu * (B' * ξtildex))
Σ_in = Σu - tmp' * Λtildex * tmp
```

which reads as a maintainer warning that the rule below is defective.

## Where it came from

I traced it rather than just deleting it, and the provenance is worth recording. `git log -S "calculate marginals of input WRONG"` gives exactly one commit: **edf799f4** (2021-08-10), titled *"fix BIFM input update rule"*. Before that commit the comment read plainly `# calculate marginals of input`; the commit rewrote the rule into the dual NUV-EM parameterisation (`ξtildex`/`Λtildex`) **and appended `WRONG` in the same diff**.

So the marker was introduced *by the fix*, not left behind to flag something the fix failed to address. Its intent is genuinely ambiguous — most plausibly a note that the *previous* formulation had been wrong, landing on the new lines by accident, or a note-to-self. What it cannot be is a live warning anyone has acted on: it has survived five years and the rule ships in production with test coverage.

## Change

Rewritten to `# calculate the marginal of the input`, matching the `# return input marginal` comment eight lines below.

Comment only — no code change, so no test accompanies it. `rules:BIFM:in` (66 assertions) and the rest of the BIFM suite pass unchanged.

## Scope

This is **not** a re-derivation of the rule. The reporting issue stated it verified the body against the NUV-EM derivation in `znext.jl`/`out.jl` and found no defect; I have not repeated that work, and this PR does not claim the rule is correct — only that this comment is not evidence that it isn't. If anyone does suspect the rule, that deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)