### PR TITLE
Give a clear error when a linked datavar receives a non-PointMass marginal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Linking a `DataVariable` to a variable whose marginal is not a `PointMass` (e.g. a `RandomVariable`) now raises an informative error naming each offending argument by position and type, explaining that a linked data variable is a deterministic function of observed point values, and pointing at the alternatives. Previously this surfaced as a bare `MethodError: no method matching __apply_link(...)`, which named only an internal helper ([#634](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/634))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/variables/data.jl
+++ b/src/variables/data.jl
@@ -150,8 +150,34 @@ __link_getmarginal(l::AbstractVariable) = get_stream_of_marginals(l)
 __link_getmarginal(l::AbstractArray{<:AbstractVariable}) =
     collectLatest(map(get_stream_of_marginals, l))
 
-__apply_link(f::F, args) where {F} = __apply_link(f, getdata.(args))
-__apply_link(f::F, args::NTuple{N, PointMass}) where {F, N} = f(mean.(args)...)
+__apply_link(f::F, args) where {F} = __apply_link_data(f, getdata.(args))
+
+__apply_link_data(f::F, data::NTuple{N, PointMass}) where {F, N} =
+    f(mean.(data)...)
+
+# A linked `DataVariable` must be a deterministic function of *point* values: the
+# transformation is applied to plain numbers, not to distributions. Linking to a
+# `RandomVariable` therefore delivers a full posterior here, which has no meaningful
+# point value to substitute. Previously this produced a bare `MethodError` mentioning
+# only `__apply_link`, which gives no indication of what the user did wrong.
+function __apply_link_data(f::F, data::Tuple) where {F}
+    offenders = join(
+        (
+            "  argument $(i) :: $(typeof(d))" for
+            (i, d) in enumerate(data) if !(d isa PointMass)
+        ),
+        "\n",
+    )
+    error(
+        """
+        Cannot apply the link function `$(f)` to a linked data variable: every linked argument must resolve to a `PointMass`, but the following did not:
+        $(offenders)
+
+        A linked data variable is a deterministic function of observed point values, so its arguments must be constants or other data variables holding observations. Linking to a random variable is not supported, because its marginal is a distribution rather than a point value.
+
+        If you intended to use the random variable's expectation, link to a data variable that you update explicitly with `new_observation!`, or introduce a deterministic node into the model instead.""",
+    )
+end
 
 """
     new_observation!(datavar::DataVariable, data)

--- a/test/variables/data_tests.jl
+++ b/test/variables/data_tests.jl
@@ -135,11 +135,7 @@ end
         err = try
             __apply_link_data(
                 +,
-                (
-                    NormalMeanVariance(0.0, 1.0),
-                    PointMass(1.0),
-                    Gamma(1.0, 1.0),
-                ),
+                (NormalMeanVariance(0.0, 1.0), PointMass(1.0), Gamma(1.0, 1.0)),
             )
             nothing
         catch e

--- a/test/variables/data_tests.jl
+++ b/test/variables/data_tests.jl
@@ -92,6 +92,101 @@ end
     end
 end
 
+@testitem "DataVariable: linking to a non-PointMass marginal gives an informative error" begin
+    using BayesBase, Distributions, ExponentialFamily
+    import ReactiveMP:
+        DataVariable,
+        DataVariableActivationOptions,
+        RandomVariable,
+        RandomVariableActivationOptions,
+        activate!,
+        get_stream_of_marginals,
+        __apply_link,
+        __apply_link_data
+
+    include("../testutilities.jl")
+
+    # A linked data variable applies its transform to *point* values. Linking it to
+    # something whose marginal is a distribution used to fail with a bare `MethodError`
+    # naming only the internal `__apply_link`, which tells the user nothing about what
+    # they did wrong (issue #634).
+
+    @testset "the error names the offending argument and its type" begin
+        err = try
+            __apply_link_data(+, (PointMass(1.0), NormalMeanVariance(0.0, 1.0)))
+            nothing
+        catch e
+            e
+        end
+
+        @test err isa ErrorException
+        @test occursin("must resolve to a `PointMass`", err.msg)
+        # Points at the specific argument, by position and by type.
+        @test occursin("argument 2", err.msg)
+        @test occursin("NormalMeanVariance", err.msg)
+        # Does not mention the first argument, which was fine.
+        @test !occursin("argument 1", err.msg)
+        # Explains why, and what to do instead.
+        @test occursin("random variable", err.msg)
+        @test occursin("new_observation!", err.msg)
+    end
+
+    @testset "every offending argument is listed" begin
+        err = try
+            __apply_link_data(
+                +,
+                (
+                    NormalMeanVariance(0.0, 1.0),
+                    PointMass(1.0),
+                    Gamma(1.0, 1.0),
+                ),
+            )
+            nothing
+        catch e
+            e
+        end
+
+        @test err isa ErrorException
+        @test occursin("argument 1", err.msg)
+        @test occursin("argument 3", err.msg)
+        @test !occursin("argument 2", err.msg)
+    end
+
+    @testset "reached through the real entry point, which receives Marginals" begin
+        # `activate!` wires `__apply_link(f, getrecent.(args))`, where each element is the
+        # `Marginal` most recently emitted by a linked variable's marginal stream. This is the
+        # path an actual model takes, so drive it with `Marginal`s rather than raw data.
+        err = try
+            __apply_link(
+                +,
+                (
+                    Marginal(PointMass(1.0), true, false),
+                    Marginal(NormalMeanVariance(0.0, 1.0), false, false),
+                ),
+            )
+            nothing
+        catch e
+            e
+        end
+
+        @test err isa ErrorException
+        @test occursin("must resolve to a `PointMass`", err.msg)
+        @test occursin("argument 2", err.msg)
+    end
+
+    @testset "the all-PointMass path is unaffected" begin
+        # The valid case must still work, and must not go anywhere near the error branch.
+        @test __apply_link_data(+, (PointMass(2.0), PointMass(3.0))) == 5.0
+        @test __apply_link(
+            *,
+            (
+                Marginal(PointMass(2.0), true, false),
+                Marginal(PointMass(3.0), true, false),
+            ),
+        ) == 6.0
+    end
+end
+
 @testitem "DataVariable: linked variable" begin
     using BayesBase
     import ReactiveMP:


### PR DESCRIPTION
Closes #634.

## Problem

`__apply_link` had two methods:

```julia
__apply_link(f::F, args) where {F} = __apply_link(f, getdata.(args))              # unwrap Marginals, recurse
__apply_link(f::F, args::NTuple{N, PointMass}) where {F, N} = f(mean.(args)...)   # apply the transform
```

When a linked argument's marginal is a distribution rather than a point mass — which is what happens when a `DataVariable` is linked to a `RandomVariable` — neither method applies on the second call, and the user gets

```
MethodError: no method matching __apply_link(::typeof(+), ::Tuple{...})
```

naming only an internal helper, with no indication of what they did wrong.

## Change

The unwrapping step is now `__apply_link_data`, so the two concerns no longer share a name, and a `::Tuple` fallback raises an informative error listing:

- **every offending argument, by position and concrete type** — valid arguments are deliberately *not* listed, so the message stays short when one link out of several is at fault;
- **why** point values are required (the transform is applied to plain numbers);
- **what to do instead**.

### Why restructure instead of adding a third method

Adding a `::Tuple`-typed guard alongside the existing untyped `__apply_link` would have been a dispatch trap: `Tuple` is more specific than the untyped parameter, so the guard would have intercepted the incoming tuple of `Marginal`s *before* unwrapping and errored on every valid call. Separating the entry point from the data-level dispatch avoids that entirely.

## Verification

| `src/variables/data.jl` | new testset |
|---|---|
| reverted to `main` | **3 failed, 12 errored** (the `MethodError`) |
| with this fix | **16 pass** |

The 468 pre-existing `DataVariable: linked variable` assertions pass in **both** runs — the valid all-`PointMass` path is untouched.

Tests cover the message content (offending position and type present, valid arguments absent, rationale and alternative present), the multiple-offender case, the real entry point driven with `Marginal`s exactly as `activate!` does, and that the valid path still computes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)