### PR TITLE
Reject observation values that cannot be a PointMass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `new_observation!` now rejects observation values that cannot be represented as a `PointMass` with an informative error naming the offending type, the accepted types, and `missing` as the likely intent. `PointMass` defines `variate_form` — and hence a usable `mean` — only for real numbers, arrays of real numbers and `UniformScaling`; wrapping anything else produced a `PointMass` that constructed fine but whose `mean` recursed between `Statistics.mean(itr)` and `BayesBase.mean(fn, ::PointMass)` until the stack overflowed. Passing `Uninformative()` in a data tuple where `missing` was meant therefore failed with a ~40,000-frame `StackOverflowError` that named neither the variable nor the mistake. Distributions get an additional note explaining that data variables hold observed point values rather than beliefs ([#588](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/588))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/variables/data.jl
+++ b/src/variables/data.jl
@@ -161,10 +161,33 @@ Provides a new observation to a [`ReactiveMP.DataVariable`](@ref) (or an array o
 The `data` is wrapped in a `PointMass` distribution and pushed as a new message.
 Pass `missing` to indicate that the observation is not available.
 """
-new_observation!(datavar::DataVariable, data) =
-    new_observation!(datavar, PointMass(data))
+function new_observation!(datavar::DataVariable, data)
+    __assert_valid_observation(datavar, data)
+    return new_observation!(datavar, PointMass(data))
+end
 new_observation!(datavar::DataVariable, data::PointMass) = next!(datavar.messageout, Message(data, false, false))
 new_observation!(datavar::DataVariable, ::Missing)       = next!(datavar.messageout, Message(missing, false, false))
+
+# `PointMass` only defines `variate_form` (and hence usable `mean`/`var`) for these payloads.
+# Wrapping anything else produces a `PointMass` that *constructs* fine but whose `mean` recurses
+# between `Statistics.mean(itr)` and `BayesBase.mean(fn, ::PointMass)` until the stack overflows,
+# which surfaces tens of thousands of frames deep with no hint of the actual mistake (issue #588).
+__assert_valid_observation(
+    ::DataVariable, ::Union{Real, AbstractArray, UniformScaling}
+) = nothing
+
+function __assert_valid_observation(datavar::DataVariable, data::D) where {D}
+    label = something(datavar.label, "")
+    named = isempty(string(label)) ? "" : " for `$(label)`"
+    error(
+        """
+        Invalid observation$(named): `$(D)` cannot be used as observed data.
+
+        Observations must be a real number, an array of real numbers, or a `UniformScaling`. Got a value of type `$(D)`.
+
+        If you meant to indicate that this observation is not available, pass `missing` instead$(D <: Distribution ? ".\n\nPassing a distribution as data is not supported: data variables hold observed point values, not beliefs. To place a prior on a quantity, make it a random variable in the model instead." : ".")""",
+    )
+end
 
 function new_observation!(
     datavars::AbstractArray{<:DataVariable}, data::AbstractArray

--- a/test/variables/data_tests.jl
+++ b/test/variables/data_tests.jl
@@ -92,6 +92,97 @@ end
     end
 end
 
+@testitem "DataVariable: invalid observation types are rejected with a clear error" begin
+    using BayesBase, Distributions, ExponentialFamily, LinearAlgebra
+    import ReactiveMP: DataVariable, datavar, new_observation!, Uninformative
+
+    # `PointMass` defines `variate_form` -- and therefore a usable `mean` -- only for reals,
+    # arrays of reals and `UniformScaling`. Wrapping anything else builds a `PointMass` that
+    # constructs fine but whose `mean` recurses between `Statistics.mean(itr)` and
+    # `BayesBase.mean(fn, ::PointMass)` until the stack overflows. Issue #588 reported this as
+    # a 40,000-frame `StackOverflowError` from passing `Uninformative()` in a data tuple where
+    # `missing` was meant.
+
+    @testset "Uninformative() -- the reported case" begin
+        var = datavar()
+        err = try
+            new_observation!(var, Uninformative())
+            nothing
+        catch e
+            e
+        end
+
+        # An informative error, not a StackOverflowError.
+        @test err isa ErrorException
+        @test occursin("cannot be used as observed data", err.msg)
+        @test occursin("Uninformative", err.msg)
+        # Points the user at what they almost certainly meant.
+        @test occursin("pass `missing` instead", err.msg)
+    end
+
+    @testset "distributions get the extra explanation" begin
+        for d in (NormalMeanVariance(0.0, 1.0), Beta(1.0, 1.0), Gamma(2.0, 3.0))
+            var = datavar()
+            err = try
+                new_observation!(var, d)
+                nothing
+            catch e
+                e
+            end
+
+            @test err isa ErrorException
+            @test occursin("cannot be used as observed data", err.msg)
+            @test occursin("pass `missing` instead", err.msg)
+            # Distributions are a distinct enough mistake to warrant their own note.
+            @test occursin("not beliefs", err.msg)
+        end
+    end
+
+    @testset "the label is named when the variable has one" begin
+        var = datavar(label = :y)
+        err = try
+            new_observation!(var, Uninformative())
+            nothing
+        catch e
+            e
+        end
+
+        @test err isa ErrorException
+        @test occursin("`y`", err.msg)
+    end
+
+    @testset "all supported payloads still work" begin
+        # The guard must not narrow what has always been accepted.
+        for value in (
+            1.0,
+            -3,
+            true,
+            Float32(2.5),
+            big(1.0),
+            [1.0, 2.0],
+            [1 2; 3 4],
+            ones(2, 2, 2),
+            Diagonal([1.0, 2.0]),
+        )
+            var = datavar()
+            new_observation!(var, value)
+            @test true # did not throw
+        end
+
+        # `missing` keeps its dedicated path.
+        let var = datavar()
+            new_observation!(var, missing)
+            @test true
+        end
+
+        # An explicitly-constructed `PointMass` bypasses the check, as before.
+        let var = datavar()
+            new_observation!(var, PointMass(1.0))
+            @test true
+        end
+    end
+end
+
 @testitem "DataVariable: linked variable" begin
     using BayesBase
     import ReactiveMP:


### PR DESCRIPTION
Closes #588.

## Problem

`new_observation!(datavar, data)` wrapped **any** `data` in `PointMass(data)`. But `PointMass` defines `variate_form` — and therefore a usable `mean` — only for real numbers, arrays of real numbers, and `UniformScaling`. For anything else the `PointMass` *constructs* fine, and then `mean` recurses forever between `Statistics.mean(itr)` and `BayesBase.mean(fn, ::PointMass)`:

```
[1] mean(itr::PointMass{Uninformative})                        @ Statistics
[2] mean(fn::typeof(identity), distribution::PointMass{...})   @ BayesBase
--- the above 2 lines are repeated 39990 more times ---
```

The reporter hit this by putting `Uninformative()` in a data tuple where `missing` was meant. The resulting ~40,000-frame `StackOverflowError` names neither the variable nor the mistake.

## Change

A whitelist guard on the generic `new_observation!` method. The error names the offending type, lists what *is* accepted, and points at `missing` as the likely intent:

```
Invalid observation for `y`: `Uninformative` cannot be used as observed data.

Observations must be a real number, an array of real numbers, or a `UniformScaling`. Got a value of type `Uninformative`.

If you meant to indicate that this observation is not available, pass `missing` instead.
```

Distributions get an extra sentence — passing a prior as data is a distinct enough mistake to deserve its own note:

> Passing a distribution as data is not supported: data variables hold observed point values, not beliefs. To place a prior on a quantity, make it a random variable in the model instead.

The `data::PointMass` and `::Missing` methods are untouched, so an explicitly constructed `PointMass` still bypasses the check exactly as before.

### Why this whitelist is not a narrowing risk

The accepted set is **exactly** the set `BayesBase` defines `variate_form(::Type{PointMass{T}})` for. Anything outside it had no `variate_form` and would therefore have failed somewhere downstream regardless — so nothing that previously worked is rejected.

That said, this *is* a narrowing change, so I did not rely on that argument alone:

- **The full suite was run**, not just the affected file: `RUN_AQUA=false make test` passes.
- The 468 pre-existing `DataVariable: linked variable` assertions pass **unchanged**.
- A test pins nine payload types — `Real`, negative `Int`, `Bool`, `Float32`, `BigFloat`, vector, integer matrix, 3-D array, `Diagonal` — plus `missing` and an explicit `PointMass`, so the whitelist cannot be narrowed accidentally later.

## Verification

| `src/variables/data.jl` | new testset |
|---|---|
| reverted to `main` | **errors** (the recursion) |
| with the guard | **29 pass** |

Tests cover the reported `Uninformative()` case, three distribution types, label inclusion in the message, and the payload whitelist above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)