### PR TITLE
Fix LaplaceApproximation returning a negated covariance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `LaplaceApproximation`'s `approximate_meancov` returned a **negated covariance for every input**, not just pathological ones. It computed `-cholinv(H)` from the Hessian `H` of the log-density at the mode. `-(H⁻¹)` and `(-H)⁻¹` agree in exact arithmetic, but `cholinv` factorizes via Cholesky, which is only defined for positive-definite input — and at a maximum `H` is negative-definite. Passing it directly does not raise; it silently returns a matrix that is not `H⁻¹`, so the sign flip was not compensated and the result was negative-definite. It now negates before inverting, giving `(-H)⁻¹`. Verified against the closed-form Gaussian-product answer, for which the Laplace approximation is exact. `LaplaceApproximation` had no test coverage at all, which is why this went unnoticed ([#635](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/635))
+- `LaplaceApproximation` now rejects a stationary point that is not a strict local maximum instead of returning an invalid Gaussian. `Optim.converged` only reports that the optimizer stopped moving, so for a non-log-concave integrand it could settle on a saddle point or flat region where the negated Hessian is not positive-definite. The error names the offending matrix and suggests approximation methods that do not assume local concavity ([#635](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/635))
+
+### Removed
+- Dead `d_logf` gradient closure in `LaplaceApproximation`'s `approximate_meancov`, which was constructed but never used ([#635](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/635))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/approximations/laplace.jl
+++ b/src/approximations/laplace.jl
@@ -30,8 +30,7 @@ function approximate_meancov(::LaplaceApproximation, g::Function, distribution)
     logg = (z) -> log(g(z))
     logd = (z) -> logpdf(distribution, z)
 
-    logf   = (z) -> logg(z) + logd(z)
-    d_logf = (z) -> ForwardDiff.gradient(logf, z)
+    logf = (z) -> logg(z) + logd(z)
 
     result = optimize((d) -> -(logf(d)), mean(distribution), LBFGS())
     if !Optim.converged(result)
@@ -39,7 +38,40 @@ function approximate_meancov(::LaplaceApproximation, g::Function, distribution)
     end
 
     m = Optim.minimizer(result)
-    c = -cholinv(ForwardDiff.hessian(logf, m))
+
+    # At a maximum of `logf` the Hessian `H` is negative-definite, and the Laplace covariance
+    # is `(-H)⁻¹`. Although `-(H⁻¹)` and `(-H)⁻¹` are equal in exact arithmetic, they are *not*
+    # equal here: `cholinv` factorizes via Cholesky, which is only defined for
+    # positive-definite input. Handing it the negative-definite `H` does not raise -- it
+    # silently returns a matrix that is not `H⁻¹` -- so the previous `-cholinv(H)` produced a
+    # negated, negative-definite covariance for every input, not just pathological ones.
+    # Negating first keeps `cholinv` on the positive-definite matrix it requires.
+    #
+    # `Symmetric` because `ForwardDiff.hessian` is only symmetric up to rounding, and both
+    # `isposdef` and the Cholesky factorization want an exactly symmetric argument.
+    neg_hessian = Symmetric(-ForwardDiff.hessian(logf, m))
+
+    # `Optim.converged` above only tells us the optimizer stopped moving; it does not
+    # distinguish a strict local maximum from a saddle point or a flat region. For a
+    # non-log-concave `g` (an `ExponentialLinearQuadratic` kernel, say) the stationary point
+    # may not be a maximum at all, in which case `-H` is not positive-definite and the
+    # "covariance" would come out indefinite or negative. Reject that explicitly instead of
+    # returning an invalid Gaussian.
+    if !isposdef(neg_hessian)
+        error(
+            """
+            LaplaceApproximation: the log-density is not locally concave at the mode found by the optimizer, so no Gaussian approximation exists there.
+
+            The negated Hessian must be positive-definite (equivalently, the stationary point must be a strict local maximum), but it is not — the optimizer likely converged to a saddle point or a flat region. This happens when the integrand is not log-concave.
+
+            Negated Hessian at the stationary point:
+            $(neg_hessian)
+
+            Consider a different approximation method (e.g. `GaussHermiteCubature`, `SphericalRadialCubature`, or `ImportanceSamplingApproximation`), which do not assume local concavity.""",
+        )
+    end
+
+    c = cholinv(neg_hessian)
 
     return m, c
 end

--- a/test/approximations/laplace_tests.jl
+++ b/test/approximations/laplace_tests.jl
@@ -1,0 +1,125 @@
+
+@testitem "LaplaceApproximation: recovers the exact Gaussian product" begin
+    using ReactiveMP, BayesBase, Distributions, ExponentialFamily, LinearAlgebra
+
+    import ReactiveMP: LaplaceApproximation, approximate_meancov
+
+    # For a Gaussian `g` and a Gaussian proposal the Laplace approximation is *exact*: the
+    # log-density is a quadratic, so its second-order expansion at the mode reproduces it
+    # exactly. That makes this the sharpest possible test of the method -- no Monte Carlo or
+    # quadrature error to hide behind, and the expected values are closed-form.
+    #
+    # For `g(z) = exp(-(z-μ)ᵀΛ_g(z-μ)/2)` and proposal `N(m₀, Σ₀)`:
+    #
+    #     Λ = Λ₀ + Λ_g,    m = Λ⁻¹(Λ₀m₀ + Λ_g μ),    Σ = Λ⁻¹
+    #
+    # This is also the regression test for the covariance sign: before the fix the returned
+    # covariance was the *negation* of the correct one, for every input -- a broken result that
+    # went unnoticed because `LaplaceApproximation` had no tests at all.
+
+    @testset "univariate (1-element vector)" begin
+        # proposal N(0, 1), kernel centred at 1 with precision 1
+        # ⇒ Λ = 2, Σ = 0.5, m = 0.5·1 = 0.5
+        m, c = approximate_meancov(
+            LaplaceApproximation(),
+            (z) -> exp(-sum(abs2, z .- 1.0) / 2),
+            MvNormalMeanCovariance([0.0], [1.0;;]),
+        )
+
+        @test m ≈ [0.5] atol = 1e-6
+        @test c ≈ [0.5;;] atol = 1e-8
+        # The covariance must be a valid one. This is the assertion that fails on `main`.
+        @test isposdef(c)
+        @test all(>(0), diag(c))
+    end
+
+    @testset "multivariate with correlation" begin
+        Λ₀ = [2.0 0.3; 0.3 1.5]      # proposal precision
+        Λg = [1.0 -0.2; -0.2 3.0]    # kernel precision
+        m₀ = [0.5, -1.0]
+        μg = [2.0, 1.0]
+
+        Λ = Λ₀ + Λg
+        Σ_exact = inv(Λ)
+        m_exact = Σ_exact * (Λ₀ * m₀ + Λg * μg)
+
+        m, c = approximate_meancov(
+            LaplaceApproximation(),
+            (z) -> exp(-dot(z - μg, Λg, z - μg) / 2),
+            MvNormalMeanCovariance(m₀, inv(Λ₀)),
+        )
+
+        @test m ≈ m_exact atol = 1e-6
+        @test c ≈ Σ_exact atol = 1e-8
+        @test isposdef(c)
+        @test issymmetric(Matrix(c)) || c ≈ transpose(c)
+    end
+
+    @testset "the covariance is positive-definite across a range of curvatures" begin
+        # Sweeps the kernel precision over four orders of magnitude. Every returned covariance
+        # must be positive-definite; on `main` every one of them is negative-definite.
+        for λ in (1e-2, 1.0, 1e1, 1e2)
+            m, c = approximate_meancov(
+                LaplaceApproximation(),
+                (z) -> exp(-λ * sum(abs2, z .- 0.5) / 2),
+                MvNormalMeanCovariance([0.0], [1.0;;]),
+            )
+
+            @test isposdef(c)
+            # Exact: Λ = 1 + λ
+            @test c ≈ [inv(1 + λ);;] atol = 1e-8
+        end
+    end
+end
+
+@testitem "LaplaceApproximation: rejects a stationary point that is not a maximum" begin
+    using ReactiveMP, BayesBase, Distributions, ExponentialFamily, LinearAlgebra
+
+    import ReactiveMP: LaplaceApproximation, approximate_meancov
+
+    # `Optim.converged` only reports that the optimizer stopped moving; it says nothing about
+    # whether the stationary point is a strict local maximum. When it is not, `-H` is not
+    # positive-definite and there is no Gaussian to fit -- previously this silently produced an
+    # indefinite "covariance" (issue #635).
+    #
+    # A kernel that is log-*convex* along one direction inverts the curvature the proposal
+    # supplies, so the total log-density has no maximum there.
+    @testset "log-convex kernel is rejected with an explanatory error" begin
+        # log g(z) = +2·z², so log f = 2z² - z²/2 = +1.5z²: curvature is positive, i.e. the
+        # stationary point at 0 is a minimum of log f, not a maximum.
+        err = try
+            approximate_meancov(
+                LaplaceApproximation(),
+                (z) -> exp(2 * sum(abs2, z)),
+                MvNormalMeanCovariance([0.0], [1.0;;]),
+            )
+            nothing
+        catch e
+            e
+        end
+
+        @test err !== nothing
+        if err isa ErrorException
+            # Either the explicit concavity guard fires, or the optimizer itself fails to
+            # converge on an unbounded objective. Both are acceptable refusals; what matters is
+            # that no invalid covariance is returned. When it is the guard, it must explain
+            # itself and suggest a way forward.
+            @test occursin("not locally concave", err.msg) ||
+                occursin("convergence failed", err.msg)
+            if occursin("not locally concave", err.msg)
+                @test occursin("positive-definite", err.msg)
+                @test occursin("GaussHermiteCubature", err.msg)
+            end
+        end
+    end
+
+    @testset "a valid case is not caught by the guard" begin
+        # The guard must not reject legitimate log-concave problems.
+        m, c = approximate_meancov(
+            LaplaceApproximation(),
+            (z) -> exp(-sum(abs2, z .- 1.0) / 2),
+            MvNormalMeanCovariance([0.0], [1.0;;]),
+        )
+        @test isposdef(c)
+    end
+end


### PR DESCRIPTION
Closes #635.

## The issue asked for a check; the tests found a much bigger problem

#635 asked for an `isposdef` guard before forming `-cholinv(hessian)`, on the grounds that a non-log-concave integrand could yield negative variances. Writing tests to justify that guard turned up something larger: **the method returned a covariance with the wrong sign for every input.**

```julia
c = -cholinv(ForwardDiff.hessian(logf, m))
```

At a maximum of `logf` the Hessian `H` is negative-definite, and the Laplace covariance is `(-H)⁻¹`. Since `-(H⁻¹) = (-H)⁻¹` in exact arithmetic, the expression reads as correct. But `cholinv` is `inv(fastcholesky(·))`, and Cholesky is only defined for **positive**-definite input. Handing it the negative-definite `H` **does not raise** — it silently returns a matrix that is not `H⁻¹`, so the outer negation is never compensated:

```
cholinv([-2.0])  ==  [+0.5]        # not [-0.5]
-cholinv(H)      !=  cholinv(-H)   # confirmed at 2x2
```

Measured end to end, proposal `N(0, 1)` with a unit-precision Gaussian kernel:

```
returned:  c = [-0.4999999999999999]
exact:     c = [+0.5]
```

Every covariance this method has ever produced was negative-definite. It went unnoticed because **`LaplaceApproximation` had no test coverage at all** and no in-repo callers, though it is exported and documented as a selectable approximation method for delta nodes.

## Changes

1. **Negate before inverting** — `cholinv(Symmetric(-H))` — so `cholinv` receives the positive-definite matrix it requires. `Symmetric` because `ForwardDiff.hessian` is symmetric only up to rounding, and both `isposdef` and the factorization want an exactly symmetric argument.

2. **The concavity guard #635 asked for**, which is what remains once the sign is right. `Optim.converged` reports only that the optimizer stopped moving, not that it stopped at a strict local maximum; for a non-log-concave integrand it can settle on a saddle or flat region where `-H` is not positive-definite and no Gaussian exists. Now errors with the offending matrix and points at `GaussHermiteCubature` / `SphericalRadialCubature` / `ImportanceSamplingApproximation`, which do not assume local concavity.

3. **Removed the dead `d_logf` closure**, constructed but never used.

### One correction to the issue

It states the fix should "verify … the optimizer's convergence/maximum status before forming `c`". Convergence *was* already checked, at `laplace.jl:37-39`. The gap was in what that check guarantees, not its absence.

## Verification

New `test/approximations/laplace_tests.jl`. For a Gaussian kernel and Gaussian proposal the Laplace approximation is **exact** — the log-density is quadratic, so its second-order expansion reproduces it — which lets the tests assert closed-form values at `1e-8` rather than settling for approximate agreement:

```
Λ = Λ₀ + Λ_g,    m = Λ⁻¹(Λ₀m₀ + Λ_g μ),    Σ = Λ⁻¹
```

Covers a 1-element case, a correlated 2×2 case, a sweep of kernel precisions across four orders of magnitude, the rejection path, and a check that the guard does not reject valid log-concave problems.

| `src/approximations/laplace.jl` | result |
|---|---|
| `main` | **every covariance assertion fails** — wrong sign, `isposdef` false throughout |
| with this PR | **21 pass** |

## Note on severity

This is worth flagging beyond the issue's "MINOR" label. Any model using `LaplaceApproximation` for a delta-node approximation was getting a negative-definite covariance, which either propagates a nonsense belief or throws further downstream depending on the consumer. No in-repo code path uses it, so ReactiveMP's own tests could not have caught it — but user code selecting `LaplaceApproximation` explicitly would have been affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)