### PR TITLE
Handle a zero-covariance input in the delta-node RTS smoother

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A zero-covariance inbound message no longer crashes the `DeltaFn(:ins)` joint marginal rules. `unscented_statistics`' zero-covariance fallback returned `nothing` for the cross-covariance — "not computed" rather than a degenerate value of the same kind as the zeros beside it — and the marginal rules feed that third return value straight into `smoothRTS`, failing with `MethodError: no method matching *(::Nothing, ::Float64)`. It now returns a genuine zero cross-covariance, which is both correct (a deterministic input has zero covariance with anything) and type-stable with the non-degenerate path ([#630](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/630))
+- `smoothRTS` now short-circuits when the forward output covariance is singular or non-finite, returning the forward inbound statistics unchanged. A deterministic node output cannot be revised by the backward message, so that *is* the smoothed marginal. Previously `cholinv(V_tilde)` on a zero covariance returned `Inf` rather than raising, so `D_tilde = C_tilde * W_tilde` evaluated to `0 * Inf = NaN` and a silently corrupted marginal propagated. This affects both the `Unscented` and `Linearization` delta-node paths ([#630](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/630))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/src/approximations/rts.jl
+++ b/src/approximations/rts.jl
@@ -4,6 +4,19 @@ RTS smoother update for inbound marginal; based on (Petersen et al. 2018; On App
 function smoothRTS(
     m_tilde, V_tilde, C_tilde, m_fw_in, V_fw_in, m_bw_out, V_bw_out
 )
+    # A singular forward output covariance means the transformed input is deterministic: the
+    # node's output carries no uncertainty, so the backward message cannot revise the input and
+    # the smoothed inbound marginal is exactly the forward one. This happens whenever an inbound
+    # message has zero covariance, in which case `unscented_statistics` (and the linearization
+    # equivalent) return `V_tilde = 0` and `C_tilde = 0`.
+    #
+    # Without this short-circuit, `W_tilde = cholinv(V_tilde)` is `Inf` rather than an error, so
+    # `D_tilde = C_tilde * W_tilde` evaluates to `0 * Inf = NaN` and a silently corrupted
+    # marginal propagates instead of the correct degenerate one.
+    if __rts_is_singular(V_tilde)
+        return (m_fw_in, V_fw_in)
+    end
+
     P = cholinv(V_tilde + V_bw_out)
     W_tilde = cholinv(V_tilde)
     D_tilde = C_tilde * W_tilde
@@ -12,4 +25,9 @@ function smoothRTS(
     m_in = m_fw_in + D_tilde * (m_out - m_tilde)
 
     return (m_in, V_in) # Statistics for marginal on in
+end
+
+__rts_is_singular(V_tilde::Real) = iszero(V_tilde) || !isfinite(V_tilde)
+function __rts_is_singular(V_tilde::AbstractMatrix)
+    return !all(isfinite, V_tilde) || iszero(det(V_tilde))
 end

--- a/src/approximations/unscented.jl
+++ b/src/approximations/unscented.jl
@@ -148,10 +148,19 @@ function statistic_estimation(
     return (m_tilde, V_tilde, C_tilde)
 end
 
+# A zero-covariance input means the input is known exactly, so the transformed output is a
+# point too: zero output covariance *and* zero cross-covariance with the input.
+#
+# The cross-covariance used to be returned as `nothing`, which is not a degenerate value of the
+# same kind as the zeros beside it -- it is "not computed". Consumers that legitimately asked
+# for it (`Val(true)`, i.e. the `DeltaFn(:ins)` marginal rules) then fed `nothing` into
+# arithmetic and failed with `MethodError: no method matching *(::Nothing, ::Float64)`. Callers
+# that did not ask for it discard the third element anyway, so returning a genuine zero is
+# correct for both and keeps the return type stable.
 __unscented_parameters_zero_covariance(m::T) where {T <: Real} =
-    (m, zero(T), nothing)
+    (m, zero(T), zero(T))
 __unscented_parameters_zero_covariance(m::AbstractVector{T}) where {T <: Real} =
-    (m, zeros(T, length(m), length(m)), nothing)
+    (m, zeros(T, length(m), length(m)), zeros(T, length(m), length(m)))
 
 # Single univariate variable
 function unscented_statistics(

--- a/test/approximations/rts_tests.jl
+++ b/test/approximations/rts_tests.jl
@@ -1,0 +1,190 @@
+
+@testitem "smoothRTS: a singular forward covariance yields the forward marginal unchanged" begin
+    using ReactiveMP, BayesBase, Distributions, ExponentialFamily, LinearAlgebra
+
+    import ReactiveMP: smoothRTS
+
+    # If the transformed input has zero (or non-finite) covariance, the node's output carries no
+    # uncertainty, so the backward message cannot revise the input: the smoothed inbound
+    # marginal is exactly the forward one.
+    #
+    # Previously `W_tilde = cholinv(V_tilde)` produced `Inf` rather than raising -- `cholinv` on
+    # a scalar is just `inv` -- so `D_tilde = C_tilde * W_tilde` became `0 * Inf = NaN` and a
+    # silently corrupted marginal propagated.
+
+    @testset "scalar, zero V_tilde" begin
+        m_in, V_in = smoothRTS(4.0, 0.0, 0.0, 2.0, 3.0, 5.0, 1.0)
+        @test m_in == 2.0    # the forward mean
+        @test V_in == 3.0    # the forward covariance
+        @test !isnan(m_in)
+        @test !isnan(V_in)
+    end
+
+    @testset "scalar, non-finite V_tilde" begin
+        for bad in (Inf, NaN)
+            m_in, V_in = smoothRTS(4.0, bad, 0.0, 2.0, 3.0, 5.0, 1.0)
+            @test m_in == 2.0
+            @test V_in == 3.0
+        end
+    end
+
+    @testset "matrix, singular V_tilde" begin
+        m_fw = [1.0, -2.0]
+        V_fw = [2.0 0.5; 0.5 1.0]
+
+        # Exactly zero
+        m_in, V_in = smoothRTS(
+            [0.0, 0.0],
+            zeros(2, 2),
+            zeros(2, 2),
+            m_fw,
+            V_fw,
+            [1.0, 1.0],
+            [1.0 0.0; 0.0 1.0],
+        )
+        @test m_in == m_fw
+        @test V_in == V_fw
+
+        # Rank-deficient but non-zero
+        singular = [1.0 1.0; 1.0 1.0]
+        m_in, V_in = smoothRTS(
+            [0.0, 0.0],
+            singular,
+            zeros(2, 2),
+            m_fw,
+            V_fw,
+            [1.0, 1.0],
+            [1.0 0.0; 0.0 1.0],
+        )
+        @test m_in == m_fw
+        @test V_in == V_fw
+    end
+
+    @testset "a well-conditioned V_tilde is unaffected" begin
+        # The guard must not alter the normal path. Reference values computed from the RTS
+        # equations directly.
+        m_tilde, V_tilde, C_tilde = 4.0, 2.0, 1.5
+        m_fw_in, V_fw_in = 2.0, 3.0
+        m_bw_out, V_bw_out = 5.0, 1.0
+
+        P = inv(V_tilde + V_bw_out)
+        W_tilde = inv(V_tilde)
+        D_tilde = C_tilde * W_tilde
+        expected_V = V_fw_in + D_tilde * (V_bw_out * P * C_tilde - C_tilde)
+        m_out = V_tilde * P * m_bw_out + V_bw_out * P * m_tilde
+        expected_m = m_fw_in + D_tilde * (m_out - m_tilde)
+
+        m_in, V_in = smoothRTS(
+            m_tilde, V_tilde, C_tilde, m_fw_in, V_fw_in, m_bw_out, V_bw_out
+        )
+
+        @test m_in ≈ expected_m
+        @test V_in ≈ expected_V
+        # And it genuinely moved off the forward statistics, so the test above is not vacuous.
+        @test m_in != m_fw_in
+    end
+end
+
+@testitem "Unscented: a zero-covariance input gives a zero cross-covariance, not `nothing`" begin
+    using ReactiveMP,
+        BayesBase, Distributions, ExponentialFamily, LinearAlgebra, Logging
+
+    import ReactiveMP: Unscented, unscented_statistics
+
+    # `__unscented_parameters_zero_covariance` returned `nothing` for the cross-covariance --
+    # "not computed" rather than a degenerate value of the same kind as the zeros beside it.
+    # Callers that legitimately requested it (`Val(true)`) then fed `nothing` into arithmetic
+    # (issue #630).
+
+    @testset "univariate" begin
+        (m, V, C) = with_logger(SimpleLogger(IOBuffer())) do
+            unscented_statistics(
+                Unscented(), Val(true), (x) -> x^2, (1.0,), (0.0,)
+            )
+        end
+
+        @test m == 1.0            # g(1) = 1
+        @test iszero(V)
+        @test C !== nothing
+        @test iszero(C)
+        # Type-stable with the non-degenerate path, which returns a `Float64`.
+        @test C isa Real
+    end
+
+    @testset "multivariate" begin
+        (m, V, C) = with_logger(SimpleLogger(IOBuffer())) do
+            unscented_statistics(
+                Unscented(),
+                Val(true),
+                (x) -> x .^ 2,
+                ([1.0, 2.0],),
+                (zeros(2, 2),),
+            )
+        end
+
+        @test m == [1.0, 4.0]
+        @test all(iszero, V)
+        @test C !== nothing
+        @test all(iszero, C)
+    end
+
+    @testset "the non-degenerate path still returns a real cross-covariance" begin
+        (m, V, C) = unscented_statistics(
+            Unscented(), Val(true), (x) -> x^2, (1.0,), (2.0,)
+        )
+        @test C isa Real
+        @test !iszero(C)
+        @test isfinite(C)
+    end
+end
+
+@testitem "DeltaFn(:ins) marginal completes for a zero-variance inbound" begin
+    using ReactiveMP,
+        BayesBase, Distributions, ExponentialFamily, LinearAlgebra, Logging
+
+    import ReactiveMP: DeltaMeta, Unscented, Linearization
+
+    # The reachable path reported in #630: `@marginalrule DeltaFn(:ins)` feeds
+    # `unscented_statistics`' third return value straight into `smoothRTS`, so a zero-variance
+    # inbound message used to fail with
+    #   MethodError: no method matching *(::Nothing, ::Float64)
+    #
+    # A zero-variance inbound means the input is known exactly, so the correct smoothed marginal
+    # is that same point -- which is what both approximation methods now return.
+    for method in (Unscented(), Linearization())
+        @testset "$(nameof(typeof(method)))" begin
+            meta = DeltaMeta(method = method, inverse = nothing)
+
+            result = with_logger(SimpleLogger(IOBuffer())) do
+                @call_marginalrule DeltaFn{(x) -> x^2}(:ins) (
+                    m_out = NormalMeanVariance(2.0, 1.0),
+                    m_ins = ManyOf(NormalMeanVariance(1.0, 0.0)),
+                    meta = meta,
+                )
+            end
+
+            m, V = mean_cov(result)
+            @test m == 1.0        # unchanged: the input was already deterministic
+            @test iszero(V)
+            @test !isnan(m)
+            @test !isnan(V)
+        end
+    end
+
+    @testset "a non-degenerate inbound is unaffected" begin
+        # Guards against the short-circuit swallowing the normal path.
+        meta = DeltaMeta(method = Unscented(), inverse = nothing)
+        result = @call_marginalrule DeltaFn{(x) -> x^2}(:ins) (
+            m_out = NormalMeanVariance(2.0, 1.0),
+            m_ins = ManyOf(NormalMeanVariance(1.0, 0.5)),
+            meta = meta,
+        )
+
+        m, V = mean_cov(result)
+        @test isfinite(m)
+        @test V > 0
+        # The backward message did move the marginal away from the forward input.
+        @test m != 1.0
+        @test V != 0.5
+    end
+end


### PR DESCRIPTION
Closes #630.

## Two layers of the same defect

### Layer 1 — `nothing` where a zero belongs

`__unscented_parameters_zero_covariance` returned zeros for the mean and covariance but `nothing` for the cross-covariance. `nothing` means "not computed" — but callers passing `Val(true)` have explicitly asked for it, and `@marginalrule DeltaFn(:ins)` feeds that third return value straight into `smoothRTS`:

```
MethodError: no method matching *(::Nothing, ::Float64)
```

It now returns a genuine zero. That is not a placeholder: a deterministic input has zero covariance with anything, so zero is the *correct* value. It also restores type stability with the non-degenerate path, which returns a `Float64`. `Val(false)` callers discard the third element, so nothing changes for them.

### Layer 2 — fixing that alone yields `NaN` instead of a crash

`smoothRTS` then computes `W_tilde = cholinv(V_tilde)` on a zero covariance. Since `cholinv` on a scalar is just `inv`, that returns **`Inf` rather than raising**, so `D_tilde = C_tilde * W_tilde` becomes `0 * Inf = NaN` and a silently corrupted marginal propagates in place of the crash — strictly worse.

`smoothRTS` now short-circuits when the forward output covariance is singular or non-finite, returning the forward inbound statistics unchanged. That is the correct answer rather than a bail-out: a deterministic node output carries no information for the backward message to contribute, so the smoothed inbound marginal *is* the forward one. Both the `Unscented` and `Linearization` delta paths share `smoothRTS` and are both verified.

## One correction to the issue's diagnosis, in the fix's favour

The issue predicted that *"`cholinv(zeros)` is singular before that"* — i.e. that `cholinv` would raise before the `MethodError`. It does not. `cholinv(0.0)` returns `Inf` silently, so the `MethodError` on `C_tilde * W_tilde` comes first, exactly as the issue's own title said. I verified this directly before writing the fix; it matters because it determines whether layer 2 is needed at all.

## Verification

New `test/approximations/rts_tests.jl` — neither file had coverage at this level.

- **`smoothRTS`**: zero, `Inf`, `NaN`, all-zero-matrix and rank-deficient-matrix forward covariances all return the forward statistics. A well-conditioned case is checked against the RTS equations written out independently, **and asserted to have actually moved off the forward statistics**, so the guard tests above cannot pass vacuously.
- **`unscented_statistics`**: returns a zero, `Real`, non-`nothing` cross-covariance for univariate and multivariate zero-covariance inputs, and still a non-zero one otherwise.
- **`DeltaFn(:ins)`**: completes for *both* approximation methods with a zero-variance inbound, returning the input point unchanged; a non-degenerate inbound is asserted to still move, so the short-circuit hasn't swallowed the normal path.

| `src/approximations/{rts,unscented}.jl` | result |
|---|---|
| `main` | **11 failed, 3 errored** — including the reported `MethodError: no method matching *(::Nothing, ::Float64)` |
| with this PR | **39 pass** |

The pre-existing `Unscented approximation method` and delta testsets pass in **both** runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)