### PR TITLE
Document that Message/Marginal equality ignores annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Documented that `==` on `Message` and `Marginal` compares `data`, `is_clamped` and `is_initial` but deliberately **not** `annotations`, so two messages carrying the same distribution are equal even when their `:logscale` differs. Annotations describe how a message was computed rather than the belief it represents; callers needing annotation-sensitive equality should compare `getannotations` explicitly. Added to both docstrings with runnable doctests and to the message library page; behaviour is unchanged ([#632](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/632))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/docs/src/lib/message.md
+++ b/docs/src/lib/message.md
@@ -43,6 +43,9 @@ From an implementation point a view the `Message` structure does nothing but hol
 However, this object is used extensively in Julia's multiple dispatch. 
 Our implementation also uses extra `is_initial` and `is_clamped` fields to determine if [product of two messages](@ref lib-messages-product) results in `is_initial` or `is_clamped` posterior marginal. Each message also carries an [`AnnotationDict`](@ref) for optional metadata such as log-scale factors or computation history (see [Annotations](@ref lib-annotations)).
 
+!!! note "Equality ignores annotations"
+    `==` on `Message` (and on [`Marginal`](@ref)) compares `data`, `is_clamped` and `is_initial`, but **not** `annotations`. Two messages carrying the same distribution therefore compare equal even when their annotations differ — including `:logscale`, which underpins free-energy bookkeeping. This is intentional: annotations describe *how* a message was computed, not the belief it represents. If you need annotation-sensitive equality (in a cache key, a `unique` call, or your own code), compare [`ReactiveMP.getannotations`](@ref) explicitly alongside the messages. See the `Message` docstring for a worked example.
+
 ```@docs
 ReactiveMP.getdata(message::Message)
 ReactiveMP.is_clamped(message::Message)

--- a/src/marginal.jl
+++ b/src/marginal.jl
@@ -38,6 +38,33 @@ false
 julia> is_initial(message)
 true
 ```
+
+# Equality
+
+`==` compares `data`, `is_clamped` and `is_initial`, but **not** `annotations` — matching
+[`Message`](@ref). Two marginals carrying the same distribution are equal even when their
+annotations differ:
+
+```jldoctest
+julia> using ReactiveMP, BayesBase, ExponentialFamily
+
+julia> a = Marginal(NormalMeanVariance(0.0, 1.0), false, false);
+
+julia> b = Marginal(NormalMeanVariance(0.0, 1.0), false, false);
+
+julia> ReactiveMP.annotate!(ReactiveMP.getannotations(b), :logscale, 42.0);
+
+julia> a == b
+true
+
+julia> ReactiveMP.getannotations(a) == ReactiveMP.getannotations(b)
+false
+
+```
+
+This is intentional: annotations are out-of-band metadata about *how* a marginal was computed,
+not part of the belief it represents. Compare `getannotations` explicitly when you need
+annotation-sensitive equality.
 """
 mutable struct Marginal{D}      # `mutable` structure here appears to be more performance
     const data        :: D      # in `RxInfer` benchmarks

--- a/src/message.jl
+++ b/src/message.jl
@@ -46,6 +46,33 @@ julia> is_initial(message)
 true
 
 ```
+
+# Equality
+
+`==` compares `data`, `is_clamped` and `is_initial`, but **not** `annotations`. Two messages
+carrying the same distribution are equal even when their annotations differ — including
+`:logscale`, which underpins free-energy bookkeeping:
+
+```jldoctest
+julia> using ReactiveMP, BayesBase, ExponentialFamily
+
+julia> a = Message(NormalMeanVariance(0.0, 1.0), false, false);
+
+julia> b = Message(NormalMeanVariance(0.0, 1.0), false, false);
+
+julia> ReactiveMP.annotate!(ReactiveMP.getannotations(b), :logscale, 42.0);
+
+julia> a == b
+true
+
+julia> ReactiveMP.getannotations(a) == ReactiveMP.getannotations(b)
+false
+
+```
+
+This is intentional: annotations are out-of-band metadata about *how* a message was computed,
+not part of the belief the message represents. Compare `getannotations` explicitly when you
+need annotation-sensitive equality.
 """
 mutable struct Message{D} <: AbstractMessage    # `mutable` structure here appears to be more performance
     const data        :: D                      # in `RxInfer` benchmarks

--- a/test/message_tests.jl
+++ b/test/message_tests.jl
@@ -1,3 +1,55 @@
+@testitem "Message/Marginal equality ignores annotations" begin
+    using ReactiveMP, BayesBase, Distributions, ExponentialFamily
+
+    import ReactiveMP:
+        Message, Marginal, AnnotationDict, annotate!, getannotations
+
+    # `==` deliberately compares only `data`, `is_clamped` and `is_initial` -- annotations are
+    # out-of-band metadata about *how* a message was computed, not part of the belief it
+    # represents. Issue #632 asked whether this is intentional; it is, and it is now documented
+    # in the `Message`/`Marginal` docstrings and in docs/src/lib/message.md.
+    #
+    # These tests pin the semantics so the documented contract cannot drift silently in either
+    # direction.
+
+    for Wrapper in (Message, Marginal)
+        @testset "$(Wrapper)" begin
+            distribution = NormalMeanVariance(0.0, 1.0)
+
+            @testset "differing annotations do not break equality" begin
+                plain     = Wrapper(distribution, false, false)
+                annotated = Wrapper(distribution, false, false)
+                annotate!(getannotations(annotated), :logscale, 42.0)
+
+                @test plain == annotated
+                # ... while the annotation dicts themselves are clearly different.
+                @test getannotations(plain) != getannotations(annotated)
+            end
+
+            @testset "differing :logscale values do not break equality either" begin
+                left  = Wrapper(distribution, false, false)
+                right = Wrapper(distribution, false, false)
+                annotate!(getannotations(left), :logscale, 1.0)
+                annotate!(getannotations(right), :logscale, 2.0)
+
+                @test left == right
+                @test getannotations(left) != getannotations(right)
+            end
+
+            @testset "the three compared fields still matter" begin
+                # Guards against the above being vacuously true.
+                base = Wrapper(distribution, false, false)
+
+                @test base !=
+                    Wrapper(NormalMeanVariance(1.0, 1.0), false, false)
+                @test base != Wrapper(distribution, true, false)
+                @test base != Wrapper(distribution, false, true)
+                @test base == Wrapper(distribution, false, false)
+            end
+        end
+    end
+end
+
 @testitem "Message" begin
     using Random, ReactiveMP, BayesBase, Distributions, ExponentialFamily
 


### PR DESCRIPTION
Closes #632.

## Verdict: intentional, but undocumented

`Base.:(==)` on `Message` and `Marginal` compares `data`, `is_clamped` and `is_initial`, but not `annotations`. The issue asked whether that is deliberate and observed it was documented nowhere.

It is deliberate. Annotations are out-of-band metadata about *how* a message was computed — log-scale factors, input-argument traces — not part of the belief the message represents. Two messages carrying the same distribution should compare equal regardless of the bookkeeping attached to them, and the alternative would make equality depend on which diagnostic processors happened to be enabled.

So **behaviour is unchanged**; what was missing is the contract.

## Changes

- **Both docstrings** gain an `# Equality` section with a runnable `jldoctest` showing two messages comparing equal while their annotation dicts differ — using the `:logscale` case the issue specifically raised.
- **`docs/src/lib/message.md`** gains a note covering both types, and gives the concrete advice for the scenarios the issue worried about (cache keys, `unique`, user code): compare `ReactiveMP.getannotations` explicitly alongside the messages.
- **Tests** pin the semantics in *both* directions:
  - differing annotations, and differing `:logscale` values specifically, do not break equality;
  - each of the three compared fields still does — so the first half cannot pass vacuously.

## Verification

- 16 new assertions pass; the pre-existing `Message` (322) and `Marginal` (270) testsets are unaffected.
- Doctests verified with `doctest(ReactiveMP)` — passes.

No behaviour change, so there is deliberately no failing-before/passing-after gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)