### PR TITLE
Strengthen weak assertions in the mixture dependency tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Strengthened the weakest assertions in the mixture-node dependency tests. `collect_latest_marginals` returns a `(Val{names}, observable)` pair, and the tests asserted only `marg_names isa Val` and `!isnothing(marg_obs)` — which a transposed, truncated or wrongly-named tuple would satisfy, even though those names are what rule dispatch keys off. They now assert the exact name tuples, and the `of(nothing)` streams are subscribed to so the test confirms they actually *emit* rather than merely that an object was returned ([#629](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/629))
+
 ## [6.3.3] - 2026-07-14
 
 ### Fixed

--- a/test/nodes/predefined/gamma_mixture_tests.jl
+++ b/test/nodes/predefined/gamma_mixture_tests.jl
@@ -9,7 +9,7 @@
 end
 
 @testitem "nodes:GammaMixtureNode" begin
-    using ReactiveMP, BayesBase, ExponentialFamily, Test
+    using ReactiveMP, BayesBase, ExponentialFamily, Rocket, Test
 
     import ReactiveMP:
         GammaMixtureNode,
@@ -150,19 +150,23 @@ end
             ),
         )
 
-        # First overload: (out, as, bs)
+        # First overload: (out, as, bs). The returned names are derived from the interfaces,
+        # so assert the actual tuple rather than merely that *some* `Val` came back -- a
+        # transposed or truncated name tuple would silently pass the weaker check, and these
+        # names are what the rule dispatch keys off.
         marg_names, marg_obs = collect_latest_marginals(
             deps, node, (node.out, node.as, node.bs)
         )
-        @test marg_names isa Val
-        @test !isnothing(marg_obs)
+        @test marg_names === Val((:out, :a, :b))
+        @test marg_obs isa Rocket.Subscribable
 
-        # Second overload: (out, switch, var)
+        # Second overload: (out, switch, var) -- a different arity, and the middle name must be
+        # `:switch` rather than repeating `:out`.
         marg_names, marg_obs = collect_latest_marginals(
             deps, node, (node.out, node.switch, node.as[1])
         )
-        @test marg_names isa Val
-        @test !isnothing(marg_obs)
+        @test marg_names === Val((:out, :switch, :a))
+        @test marg_obs isa Rocket.Subscribable
     end
 
     @testset "GammaShapeLikelihood basic checks" begin
@@ -317,7 +321,7 @@ end
 end
 
 @testitem "GammaMixtureNodeFunctionalDependencies: collect_latest_messages empty tuple" begin
-    using ReactiveMP, Test
+    using ReactiveMP, Rocket, Test
     import ReactiveMP:
         GammaMixtureNodeFunctionalDependencies,
         GammaMixtureNode,
@@ -349,7 +353,11 @@ end
     deps = GammaMixtureNodeFunctionalDependencies()
     val, obs = collect_latest_messages(deps, node, ())
     @test val === nothing
-    @test obs !== nothing
+    # `of(nothing)` is a synchronous single-value stream, so subscribing is enough to assert
+    # that it actually *emits* `nothing` -- rather than only that some object was returned.
+    emitted = []
+    subscribe!(obs, (v) -> push!(emitted, v))
+    @test emitted == [nothing]
 end
 
 @testitem "GammaShapeLikelihood: support and prod rule" begin

--- a/test/nodes/predefined/mixture_tests.jl
+++ b/test/nodes/predefined/mixture_tests.jl
@@ -1,5 +1,5 @@
 @testitem "nodes:MixtureNode" begin
-    using ReactiveMP, BayesBase, ExponentialFamily, Test
+    using ReactiveMP, BayesBase, ExponentialFamily, Rocket, Test
     import ReactiveMP:
         Mixture,
         MixtureNode,
@@ -134,13 +134,20 @@
         deps1 = MixtureNodeFunctionalDependencies()
         deps2 = RequireMarginalFunctionalDependencies()
 
+        # The empty-tuple overload returns `of(nothing)`, a synchronous single-value stream, so
+        # subscribing asserts it actually *emits* `nothing` rather than only that some object
+        # came back.
         val1, obs1 = collect_latest_marginals(deps1, node, ())
         @test val1 === nothing
-        @test obs1 !== nothing
+        emitted = []
+        subscribe!(obs1, (v) -> push!(emitted, v))
+        @test emitted == [nothing]
 
+        # `RequireMarginalFunctionalDependencies` names the marginal it requires, so assert the
+        # actual name -- `isa Val` would pass even if the wrong interface were reported.
         switchiface = NodeInterface(:switch, randomvar())
         val2, obs2 = collect_latest_marginals(deps2, node, (switchiface,))
-        @test val2 isa Val
-        @test obs2 !== nothing
+        @test val2 === Val((:switch,))
+        @test obs2 isa Rocket.Subscribable
     end
 end

--- a/test/nodes/predefined/normal_mixture_tests.jl
+++ b/test/nodes/predefined/normal_mixture_tests.jl
@@ -187,7 +187,7 @@
 end
 
 @testitem "nodes:NormalMixtureNode" begin
-    using ReactiveMP, BayesBase, ExponentialFamily, Test
+    using ReactiveMP, BayesBase, ExponentialFamily, Rocket, Test
 
     import ReactiveMP:
         NormalMixtureNode,
@@ -353,24 +353,31 @@ end
             ),
         )
 
-        # collect_latest_messages with empty tuple
+        # collect_latest_messages with empty tuple. `of(nothing)` is a synchronous single-value
+        # stream, so subscribing asserts that it actually *emits* `nothing` rather than only
+        # that some object was returned.
         val, obs = collect_latest_messages(deps, node, ())
         @test val === nothing
-        @test obs !== nothing
+        emitted = []
+        subscribe!(obs, (v) -> push!(emitted, v))
+        @test emitted == [nothing]
 
-        # collect_latest_marginals with full (out, means, precs)
+        # collect_latest_marginals with full (out, means, precs). The names come from the
+        # interfaces, so assert the actual tuple -- a transposed or truncated one would pass
+        # `isa Val`, and these names are what rule dispatch keys off.
         marg_names, marg_obs = collect_latest_marginals(
             deps, node, (node.out, node.means, node.precs)
         )
-        @test marg_names isa Val
-        @test !isnothing(marg_obs)
+        @test marg_names === Val((:out, :m, :p))
+        @test marg_obs isa Rocket.Subscribable
 
-        # collect_latest_marginals with (out, switch, var)
+        # collect_latest_marginals with (out, switch, var) -- different arity, and the middle
+        # name must be `:switch`.
         marg_names, marg_obs = collect_latest_marginals(
             deps, node, (node.out, node.switch, node.means[1])
         )
-        @test marg_names isa Val
-        @test !isnothing(marg_obs)
+        @test marg_names === Val((:out, :switch, :m))
+        @test marg_obs isa Rocket.Subscribable
     end
 
     @testset "Type-level utilities" begin


### PR DESCRIPTION
Addresses the actionable half of #629.

## What the issue got slightly wrong, and why it matters

#629 lists `@test !isnothing(...)` / `@test obs !== nothing` in the mixture tests as assertions that "assert `!isnothing(...)` / `obs !== nothing` only; never check the numeric marginal/message", and recommends replacing them with "assertions on concrete marginal/message values".

Those testsets don't compute a marginal. They exercise `collect_latest_marginals` / `collect_latest_messages`, which return a `(Val{names}, observable)` pair — stream plumbing. There is no numeric marginal available to assert, and the variables involved are un-activated `randomvar()`s whose streams cannot emit without the full graph-activation machinery. So the recommended fix isn't applicable as written.

The underlying criticism is fair, though — the assertions *were* weaker than they needed to be. Two strengthenings that do apply:

## 1. Assert the exact name tuples, not `isa Val`

The names are derived from the interfaces and are **what rule dispatch keys off**. A transposed, truncated, or wrongly-ordered tuple satisfies `isa Val` silently. Now pinned:

| site | was | now |
|---|---|---|
| `GammaMixture` (out, as, bs) | `isa Val` | `=== Val((:out, :a, :b))` |
| `GammaMixture` (out, switch, var) | `isa Val` | `=== Val((:out, :switch, :a))` |
| `NormalMixture` (out, means, precs) | `isa Val` | `=== Val((:out, :m, :p))` |
| `NormalMixture` (out, switch, var) | `isa Val` | `=== Val((:out, :switch, :m))` |
| `Mixture` require-marginal | `isa Val` | `=== Val((:switch,))` |

This also documents each overload's contract in the test itself — note the second and fourth rows, where the middle name must be `:switch` rather than repeating `:out`.

## 2. Assert the streams actually emit

The empty-tuple overloads return `of(nothing)`, which is **synchronous** — so subscribing needs no activation and turns `obs !== nothing` into a real behavioural assertion:

```julia
emitted = []
subscribe!(obs, (v) -> push!(emitted, v))
@test emitted == [nothing]
```

For the `combineLatest` cases, where emission genuinely requires activation, the assertion is tightened to `isa Rocket.Subscribable` rather than merely non-`nothing`.

## Deliberately not done

The other half of #629 asks to tighten `atol`/`rtol` in the projection-extension and analytic-vs-Monte-Carlo tests to `1e-6`–`1e-8`. **Those tolerances are sampling noise floors, not sloppiness** — the tests compare a stochastic estimate against an analytic value, and tightening them would produce flaky tests rather than stronger ones. Explained in detail on the issue.

## Verification

All **949** assertions in the mixture testsets pass — which incidentally confirms the name tuples above were the correct expectations rather than guesses.

Tests only, no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)