### PR TITLE
Name the PointMass escape hatch in the invalid-observation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The invalid-observation error added in 6.4.0 now names the third legitimate option instead of only two. It presented "a real number, an array of real numbers, or a `UniformScaling`" or `missing`, but a custom node may be defined over data that has no moments at all — text, symbols, a struct — and is fed by wrapping the value in a `PointMass` explicitly, which routes through the deliberately unvalidated `new_observation!(::DataVariable, ::PointMass)` method. That path was intentional from the start yet documented nowhere, so anyone with a genuinely non-numeric observation was told their model was wrong when it wasn't (this is exactly how the RxInfer "Large Language Models" example, whose rules dispatch on `PointMass{<:String}`, broke on 6.4.0). The error now shows the wrap, and states the price of it: such a `PointMass` has no `variate_form`, hence no `mean`/`var`/`logpdf`, so only rules dispatching on its concrete type and reading the payload with `BayesBase.getpointmass` can consume it. `Distribution` payloads deliberately do *not* get the hint — `PointMass(Beta(1, 1))` is not what anyone means, and suggesting it would route a real mistake around the guard — and keep the existing "point values, not beliefs" note. Also documented in the `new_observation!` docstring and in a new "Non-standard observations" section of the Variables page, cross-referenced from "Adding a custom node" and the inference lifecycle. Message text and documentation only; the accepted set of payloads is unchanged ([#588](https://github.com/ReactiveBayes/ReactiveMP.jl/issues/588))
+
 ## [6.4.0] - 2026-08-11
 
 ### Added

--- a/docs/src/concepts/inference-lifecycle.md
+++ b/docs/src/concepts/inference-lifecycle.md
@@ -64,6 +64,8 @@ new_observation!(y, 3.14)
 
 This call pushes a new [`Message`](@ref) wrapping a `PointMass(3.14)` into the data variable's outbound stream. The change propagates reactively through all connected factor nodes, triggering rule computations, which in turn push updated messages to downstream variables, which update their marginals.
 
+Only values a `PointMass` can represent — a real number, an array of real numbers or a `UniformScaling` — may be passed this way; anything else is rejected with an error. Data that is deliberately not numeric, consumed by a custom node, must be wrapped explicitly: see [Non-standard observations](@ref lib-variables-data-nonstandard).
+
 The result is that subscribing to the marginal stream of `x` yields updated posterior beliefs automatically:
 
 ```

--- a/docs/src/lib/nodes.md
+++ b/docs/src/lib/nodes.md
@@ -59,6 +59,8 @@ This expression registers a new node that can be used with the inference engine.
 Note, however, that the `@node` macro does not generate any message passing update rules.
 These must be defined using the [`@rule`](@ref) macro. 
 
+A custom node is not restricted to numeric data. If its rules are written for a payload that has no moments — text, symbols, a struct — the observation has to be wrapped in a `PointMass` explicitly; see [Non-standard observations](@ref lib-variables-data-nonstandard).
+
 ## [Collecting node properties](@id lib-node-collect)
 
 ```@docs

--- a/docs/src/lib/variables.md
+++ b/docs/src/lib/variables.md
@@ -105,6 +105,49 @@ ReactiveMP.datavar
 ReactiveMP.new_observation!
 ```
 
+### [Non-standard observations](@id lib-variables-data-nonstandard)
+
+There are two ways into a data variable, and they behave differently:
+
+| Call | Validated? | What happens |
+|------|-----------|--------------|
+| `new_observation!(y, value)` | Yes | `value` is checked, then wrapped in `PointMass(value)` |
+| `new_observation!(y, PointMass(value))` | No | the `PointMass` is pushed as-is |
+
+The generic method accepts a real number, an array of real numbers or a `UniformScaling`, and rejects anything else with an error naming the offending type. These are exactly the payloads for which `PointMass` defines a [`BayesBase.variate_form`](https://github.com/ReactiveBayes/BayesBase.jl) — wrapping anything else builds a `PointMass` that constructs fine, but whose `mean` recurses between `Statistics.mean(itr)` and `BayesBase.mean(fn, ::PointMass)` until the stack overflows, tens of thousands of frames away from the actual mistake.
+
+Most of the time that error is catching a genuine slip — a distribution passed where a sample was meant, or a placeholder where `missing` was meant. But not always: a **custom node** may be defined over data that is not numeric at all, such as text, symbols, or a struct describing a measurement. For those cases, wrap the value yourself:
+
+```julia
+using BayesBase # exports `PointMass`; RxInfer.jl re-exports it
+
+new_observation!(y, PointMass("some observed text"))
+```
+
+The rules of the node consuming `y` then dispatch on the concrete `PointMass` type and read the payload back with `BayesBase.getpointmass`, which is defined for every payload:
+
+```julia
+struct TextLikelihood end
+
+@node TextLikelihood Stochastic [out, θ]
+
+@rule TextLikelihood(:θ, Marginalisation) (m_out::PointMass{<:String},) = begin
+    text = BayesBase.getpointmass(m_out) # never `mean(m_out)` — see below
+    return score_text(text)
+end
+```
+
+!!! note
+    `new_observation!(::DataVariable, ::PointMass)` performs *no* validation whatsoever — `PointMass(Beta(1, 1))` goes through just as readily as `PointMass("text")`. Wrapping explicitly is an opt-in statement that you know what the payload is for, so it is your responsibility that only rules which understand it ever see it.
+
+A data variable holding a non-numeric `PointMass` comes with real constraints:
+
+- It has no `variate_form`, and therefore no usable `mean`, `var`, `cov` or `logpdf`. Always reach for `BayesBase.getpointmass` (which is not exported, so it needs qualifying or an explicit `import`); calling `mean` on it reintroduces the very stack overflow the validation exists to prevent.
+- It cannot feed the built-in numeric nodes, whose rules compute with the moments of their inbound messages. Only nodes written for the payload can be connected to it.
+- Bethe free energy is not meaningful for such an edge, since it is defined through log-densities the payload does not have.
+
+See [Adding a custom node](@ref lib-custom-node) for defining the node and its rules.
+
 ### Stream creation
 
 A `DataVariable` has two distinct directions of information flow:

--- a/src/variables/data.jl
+++ b/src/variables/data.jl
@@ -186,6 +186,12 @@ end
 Provides a new observation to a [`ReactiveMP.DataVariable`](@ref) (or an array of data variables).
 The `data` is wrapped in a `PointMass` distribution and pushed as a new message.
 Pass `missing` to indicate that the observation is not available.
+
+The value must be a real number, an array of real numbers or a `UniformScaling` — the payloads
+for which `PointMass` defines a `variate_form`, and hence a usable `mean`. Anything else is
+rejected with an informative error. An observation of a different kind, such as text consumed by
+a custom node, has to be wrapped in a `PointMass` explicitly; that method performs no validation.
+See [Non-standard observations](@ref lib-variables-data-nonstandard).
 """
 function new_observation!(datavar::DataVariable, data)
     __assert_valid_observation(datavar, data)
@@ -202,16 +208,41 @@ __assert_valid_observation(
     ::DataVariable, ::Union{Real, AbstractArray, UniformScaling}
 ) = nothing
 
+# A non-numeric payload is not always a mistake. A custom node may dispatch its rules on, say,
+# `PointMass{<:String}` and read the payload back with `getpointmass`, never calling `mean` — for
+# which the explicitly-wrapped `new_observation!(::DataVariable, ::PointMass)` method, deliberately
+# left unvalidated, is the supported route. The error points at it, since being told to pass a real
+# number is unhelpful when the observation genuinely is not one.
+#
+# Distributions are excluded from that hint: `PointMass(Beta(1, 1))` is not what anyone means, so
+# suggesting the wrap there would only route a real mistake around the guard.
+function __observation_hint(::Type{D}, varname) where {D <: Distribution}
+    return """
+    Passing a distribution as data is not supported: data variables hold observed point values, not beliefs. To place a prior on a quantity, make it a random variable in the model instead."""
+end
+
+function __observation_hint(::Type{D}, varname) where {D}
+    return """
+    If the value is *intentionally* not numeric — for example text consumed by a custom node whose rules dispatch on `PointMass{<:$(D)}` — wrap it in a `PointMass` yourself:
+
+        new_observation!($(varname), PointMass(value))
+
+    `new_observation!(::DataVariable, ::PointMass)` performs no validation, so the payload reaches the connected factor nodes untouched. In exchange, such a `PointMass` has no `variate_form`, and therefore no `mean`, `var` or `logpdf`: only rules that dispatch on its concrete type and read the payload with `BayesBase.getpointmass` can consume it. See the "Non-standard observations" section of the ReactiveMP.jl documentation."""
+end
+
 function __assert_valid_observation(datavar::DataVariable, data::D) where {D}
     label = something(datavar.label, "")
     named = isempty(string(label)) ? "" : " for `$(label)`"
+    varname = isempty(string(label)) ? "y" : string(label)
     error(
         """
         Invalid observation$(named): `$(D)` cannot be used as observed data.
 
         Observations must be a real number, an array of real numbers, or a `UniformScaling`. Got a value of type `$(D)`.
 
-        If you meant to indicate that this observation is not available, pass `missing` instead$(D <: Distribution ? ".\n\nPassing a distribution as data is not supported: data variables hold observed point values, not beliefs. To place a prior on a quantity, make it a random variable in the model instead." : ".")""",
+        If you meant to indicate that this observation is not available, pass `missing` instead.
+
+        $(__observation_hint(D, varname))""",
     )
 end
 

--- a/test/variables/data_tests.jl
+++ b/test/variables/data_tests.jl
@@ -209,6 +209,10 @@ end
         @test occursin("Uninformative", err.msg)
         # Points the user at what they almost certainly meant.
         @test occursin("pass `missing` instead", err.msg)
+        # ... and at the supported route for observations that genuinely are not numeric,
+        # which is the `::PointMass` method (issue #588 follow-up).
+        @test occursin("PointMass", err.msg)
+        @test occursin("getpointmass", err.msg)
     end
 
     @testset "distributions get the extra explanation" begin
@@ -226,6 +230,9 @@ end
             @test occursin("pass `missing` instead", err.msg)
             # Distributions are a distinct enough mistake to warrant their own note.
             @test occursin("not beliefs", err.msg)
+            # The wrap suggestion is deliberately withheld here: wrapping a prior in a
+            # `PointMass` would silently bypass the guard rather than fix the model.
+            @test !occursin("wrap it in a `PointMass`", err.msg)
         end
     end
 
@@ -271,7 +278,54 @@ end
             new_observation!(var, PointMass(1.0))
             @test true
         end
+
+        # The bypass is total, not merely relaxed: a payload with no `variate_form` at all is
+        # accepted too. This is the documented route for custom nodes over non-numeric data,
+        # so it must keep working -- see `lib-variables-data-nonstandard` in the docs.
+        let var = datavar()
+            new_observation!(var, PointMass("some observed text"))
+            @test true
+        end
     end
+end
+
+@testitem "DataVariable: an explicitly wrapped non-numeric observation reaches the nodes" begin
+    using BayesBase, Rocket
+
+    import BayesBase: getpointmass
+    import ReactiveMP:
+        DataVariable,
+        DataVariableActivationOptions,
+        datavar,
+        activate!,
+        new_observation!,
+        get_stream_of_outbound_messages,
+        get_stream_of_marginals
+
+    # A custom node may dispatch its rules on `PointMass{<:String}` and read the payload with
+    # `getpointmass`, never calling `mean`. Wrapping the observation by hand is the supported way
+    # to feed such a node, so the payload must arrive at the connected nodes untouched.
+    var = datavar(label = :y)
+    activate!(
+        var, DataVariableActivationOptions(false, false, nothing, nothing)
+    )
+
+    messages = []
+    marginals = []
+
+    subscribe!(
+        get_stream_of_outbound_messages(var, 1), (m) -> push!(messages, m)
+    )
+    subscribe!(get_stream_of_marginals(var), (m) -> push!(marginals, m))
+
+    new_observation!(var, PointMass("some observed text"))
+
+    @test length(messages) === 1
+    @test getdata(messages[1]) === PointMass("some observed text")
+    @test getpointmass(getdata(messages[1])) == "some observed text"
+
+    @test length(marginals) === 1
+    @test getdata(marginals[1]) === PointMass("some observed text")
 end
 
 @testitem "DataVariable: linked variable" begin


### PR DESCRIPTION
The invalid-observation guard added in 6.4.0 (#588) presents exactly two options — a real number, an array of reals or a `UniformScaling`, or `missing`. There is a third that is equally legitimate: a **custom node defined over data that has no moments at all** — text, symbols, a struct — fed by wrapping the value in a `PointMass` explicitly, which routes through the deliberately unvalidated `new_observation!(::DataVariable, ::PointMass)` method.

That path was intentional from the start (the original commit: *"an explicitly constructed `PointMass` still bypasses the check as before"*) but documented nowhere, so it reads as a bypass someone stumbled on rather than a supported route. The RxInfer **Large Language Models** example, whose rules dispatch on `PointMass{<:String}`, broke on 6.4.0 for exactly this reason — raw text is a perfectly good observation for it, and the error told it otherwise (fixed there in ReactiveBayes/RxInferExamples.jl#91).

**Message text and documentation only — the accepted set of payloads is unchanged.**

## The message

```
Invalid observation for `y`: `String` cannot be used as observed data.

Observations must be a real number, an array of real numbers, or a `UniformScaling`. Got a value of type `String`.

If you meant to indicate that this observation is not available, pass `missing` instead.

If the value is *intentionally* not numeric — for example text consumed by a custom node whose rules
dispatch on `PointMass{<:String}` — wrap it in a `PointMass` yourself:

    new_observation!(y, PointMass(value))

`new_observation!(::DataVariable, ::PointMass)` performs no validation, so the payload reaches the
connected factor nodes untouched. In exchange, such a `PointMass` has no `variate_form`, and therefore
no `mean`, `var` or `logpdf`: only rules that dispatch on its concrete type and read the payload with
`BayesBase.getpointmass` can consume it. See the "Non-standard observations" section of the
ReactiveMP.jl documentation.
```

`Distribution` payloads deliberately do **not** get that hint — `PointMass(Beta(1, 1))` is not what anyone means, and suggesting it would route a real mistake around the guard. They keep their existing *"point values, not beliefs"* note verbatim. The three-way branch is factored into `__observation_hint` rather than nested further into the interpolated ternary.

## Documentation

- `new_observation!` docstring now states the accepted set and the wrap.
- New **Non-standard observations** section on the Variables page: both entry points side by side, why the validation exists, a worked custom-node example (`@node` + `@rule` dispatching on `PointMass{<:String}`), and the constraints that come with a non-numeric payload — no `mean`/`var`/`logpdf`, cannot feed the built-in numeric nodes, BFE not meaningful for that edge, and that the wrap is unvalidated *in full* rather than merely relaxed.
- Cross-referenced from *Adding a custom node* and from the inference lifecycle's observation phase.

## Verification

- `RUN_AQUA=false make test` passes in full.
- `test/variables/data_tests.jl` 3500 → 3554 assertions: the reported `Uninformative()` case pins that the message names `PointMass` and `getpointmass`; the distribution cases pin that it does *not* offer the wrap; an explicit `PointMass("some observed text")` is pinned as accepted; and a new testitem activates a `datavar`, pushes a wrapped string, and asserts the payload arrives intact on both the outbound message and the marginal stream.
- `make docs` builds clean — no cross-reference or doctest warnings, so the new `lib-variables-data-nonstandard` anchor and all three links to it resolve.
- `make check-format` passes.
- All three message variants rendered by hand (labelled, unlabelled, `Beta`) to check the paragraph breaks and the indented `new_observation!` line.

## Left for a follow-up

The whitelist accepts bare `AbstractArray`, so `["a", "b"]` passes the guard while `PointMass{Vector{String}}` has no `variate_form` either — the same hole one level down. Narrowing it to `AbstractArray{<:Real}` would be breaking for anyone already relying on non-numeric arrays, so it is left alone here.

Relates to #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
